### PR TITLE
Change execute() to take ExecuteOptions directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let resp = reqwest::get("https://api.example.com/data").await?;
                 resp.text().await
             },
-            Some(
-                ExecuteOptions::new()
-                    .breakers(&["external-api"])
-                    .router("my-router-id")
-                    .metric("latency", MetricValue::Latency),
-            ),
+            ExecuteOptions::new()
+                .breakers(&["external-api"])
+                .router("my-router-id")
+                .metric("latency", MetricValue::Latency),
         )
         .await;
 
@@ -170,7 +168,7 @@ Creates a new Tripswitch client. Starts background tasks for SSE state sync, sam
 async fn execute<T, E, Fut>(
     &self,
     task: impl FnOnce() -> Fut,
-    opts: Option<ExecuteOptions>,
+    opts: ExecuteOptions,
 ) -> Result<T, ExecuteError<E>>
 where
     E: std::error::Error + Send + 'static,
@@ -289,7 +287,7 @@ pub enum ExecuteError<E> {
 `ExecuteError<E>` preserves your task's error type — use `is_breaker_error()`, `sdk_error()`, or `task_error()` to inspect:
 
 ```rust
-let result = client.execute(|| async { do_work().await }, opts).await;
+let result = client.execute(|| async { do_work().await }, ExecuteOptions::default()).await;
 match result {
     Ok(value) => { /* success */ }
     Err(e) if e.is_breaker_error() => {
@@ -341,7 +339,7 @@ fn breakers_in_region(breakers: &[BreakerMeta]) -> Vec<String> {
 let result = client
     .execute(
         || async { do_work().await },
-        Some(ExecuteOptions::new().select_breakers(breakers_in_region)),
+        ExecuteOptions::new().select_breakers(breakers_in_region),
     )
     .await;
 ```
@@ -364,11 +362,9 @@ fn production_router(routers: &[RouterMeta]) -> String {
 let result = client
     .execute(
         || async { do_work().await },
-        Some(
-            ExecuteOptions::new()
-                .select_router(production_router)
-                .metric("latency", MetricValue::Latency),
-        ),
+        ExecuteOptions::new()
+            .select_router(production_router)
+            .metric("latency", MetricValue::Latency),
     )
     .await;
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -310,14 +310,12 @@ impl Client {
     pub async fn execute<T, E, Fut>(
         &self,
         task: impl FnOnce() -> Fut,
-        opts: Option<ExecuteOptions>,
+        opts: ExecuteOptions,
     ) -> Result<T, ExecuteError<E>>
     where
         E: std::error::Error + Send + 'static,
         Fut: Future<Output = Result<T, E>>,
     {
-        let opts = opts.unwrap_or_default();
-
         // 1. Validate no conflicting options
         if opts.breakers.is_some() && opts.select_breakers.is_some() {
             return Err(Error::ConflictingOptions(
@@ -803,7 +801,10 @@ mod tests {
     async fn execute_no_breakers_passthrough() {
         let (client, _rx) = new_test_client();
         let result: Result<String, std::io::Error> = client
-            .execute(|| async { Ok("success".to_string()) }, None)
+            .execute(
+                || async { Ok("success".to_string()) },
+                ExecuteOptions::default(),
+            )
             .await
             .map_err(|e| match e {
                 ExecuteError::Task(e) => e,
@@ -826,7 +827,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("success".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["test-breaker"])),
+                ExecuteOptions::new().breakers(&["test-breaker"]),
             )
             .await;
         assert!(result.is_ok());
@@ -845,7 +846,7 @@ mod tests {
                     task_ran = true;
                     Ok::<_, std::io::Error>("should not run".to_string())
                 },
-                Some(ExecuteOptions::new().breakers(&["test-breaker"])),
+                ExecuteOptions::new().breakers(&["test-breaker"]),
             )
             .await;
 
@@ -863,7 +864,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("nope".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["hb"])),
+                ExecuteOptions::new().breakers(&["hb"]),
             )
             .await;
         assert!(result.unwrap_err().is_breaker_error());
@@ -877,7 +878,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("allowed".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["hb"])),
+                ExecuteOptions::new().breakers(&["hb"]),
             )
             .await;
         assert_eq!(result.unwrap(), "allowed");
@@ -891,7 +892,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("success".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["nonexistent"])),
+                ExecuteOptions::new().breakers(&["nonexistent"]),
             )
             .await;
         assert_eq!(result.unwrap(), "success");
@@ -906,7 +907,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("nope".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["a", "b"])),
+                ExecuteOptions::new().breakers(&["a", "b"]),
             )
             .await;
         assert!(result.unwrap_err().is_breaker_error());
@@ -921,7 +922,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("success".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["a", "b"])),
+                ExecuteOptions::new().breakers(&["a", "b"]),
             )
             .await;
         assert_eq!(result.unwrap(), "success");
@@ -939,7 +940,7 @@ mod tests {
             let result = client
                 .execute(
                     || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                    Some(ExecuteOptions::new().breakers(&["a", "b"])),
+                    ExecuteOptions::new().breakers(&["a", "b"]),
                 )
                 .await;
             if result.is_ok() {
@@ -964,7 +965,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("nope".to_string()) },
-                Some(opts),
+                opts,
             )
             .await;
         let err = result.unwrap_err();
@@ -987,7 +988,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("nope".to_string()) },
-                Some(opts),
+                opts,
             )
             .await;
         let err = result.unwrap_err();
@@ -1009,11 +1010,9 @@ mod tests {
                     tokio::time::sleep(Duration::from_millis(5)).await;
                     Ok::<_, std::io::Error>("ok".to_string())
                 },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency),
             )
             .await
             .unwrap();
@@ -1032,7 +1031,7 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(ExecuteOptions::new().router("r1")),
+                ExecuteOptions::new().router("r1"),
             )
             .await
             .unwrap();
@@ -1047,7 +1046,7 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(ExecuteOptions::new().metric("latency", MetricValue::Latency)),
+                ExecuteOptions::new().metric("latency", MetricValue::Latency),
             )
             .await
             .unwrap();
@@ -1066,13 +1065,11 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency)
-                        .tag("env", "override")
-                        .tag("endpoint", "/users"),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency)
+                    .tag("env", "override")
+                    .tag("endpoint", "/users"),
             )
             .await
             .unwrap();
@@ -1094,12 +1091,10 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency)
-                        .trace_id("trace-abc-123"),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency)
+                    .trace_id("trace-abc-123"),
             )
             .await
             .unwrap();
@@ -1115,13 +1110,11 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency)
-                        .metric("count", MetricValue::Static(1.0))
-                        .metric("amount", MetricValue::Static(99.99)),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency)
+                    .metric("count", MetricValue::Static(1.0))
+                    .metric("amount", MetricValue::Static(99.99)),
             )
             .await
             .unwrap();
@@ -1151,11 +1144,9 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("queue_depth", MetricValue::Dynamic(Box::new(|| 42.0))),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("queue_depth", MetricValue::Dynamic(Box::new(|| 42.0))),
             )
             .await
             .unwrap();
@@ -1172,11 +1163,9 @@ mod tests {
         let _result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("ok".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("custom-router-123")
-                        .metric("latency", MetricValue::Latency),
-                ),
+                ExecuteOptions::new()
+                    .router("custom-router-123")
+                    .metric("latency", MetricValue::Latency),
             )
             .await
             .unwrap();
@@ -1192,11 +1181,9 @@ mod tests {
         let result = client
             .execute(
                 || async { Err::<String, _>(std::io::Error::other("task failed")) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency),
             )
             .await;
 
@@ -1213,7 +1200,7 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("success".to_string()) },
-                Some(ExecuteOptions::new().breakers(&["b1"])),
+                ExecuteOptions::new().breakers(&["b1"]),
             )
             .await;
 
@@ -1228,11 +1215,9 @@ mod tests {
         let result = client
             .execute(
                 || async { Ok::<_, std::io::Error>("success".to_string()) },
-                Some(
-                    ExecuteOptions::new()
-                        .router("r1")
-                        .metric("latency", MetricValue::Latency),
-                ),
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency),
             )
             .await;
 

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -56,7 +56,7 @@ async fn test_execute() {
     let result: Result<String, std::io::Error> = client
         .execute(
             || async { Ok("hello".to_string()) },
-            Some(ExecuteOptions::new().metric("latency", MetricValue::Latency)),
+            ExecuteOptions::new().metric("latency", MetricValue::Latency),
         )
         .await
         .map_err(|e| match e {


### PR DESCRIPTION
## Summary
- Remove `Option<ExecuteOptions>` wrapper from `execute()` signature — now takes `ExecuteOptions` directly
- Callers use `ExecuteOptions::default()` for the no-options case instead of `None`
- Eliminates `Some(...)` noise at every call site

## Test plan
- All 146 unit tests pass
- Zero clippy warnings
- rustfmt clean