### PR TITLE
Refactor admin client with _with_opts pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,28 +427,25 @@ let client = AdminClient::builder("eb_admin_...")
     .build();
 
 // List all projects
-let projects = client.list_projects(None, None).await?;
+let projects = client.list_projects(None).await?;
 
 // Create a project
 let project = client
-    .create_project(
-        &CreateProjectInput {
-            name: "prod-payments".to_string(),
-            description: None,
-        },
-        None,
-    )
+    .create_project(&CreateProjectInput {
+        name: "prod-payments".to_string(),
+        description: None,
+    })
     .await?;
 
 // Get project details
-let project = client.get_project("proj_abc123", None).await?;
+let project = client.get_project("proj_abc123").await?;
 
 // Delete a project (requires name confirmation)
-client.delete_project("proj_abc123", "prod-payments", None).await?;
+client.delete_project("proj_abc123", "prod-payments").await?;
 
 // List breakers
 let params = ListParams { page: Some(1), per_page: Some(100) };
-let page = client.list_breakers("proj_abc123", Some(&params), None).await?;
+let page = client.list_breakers("proj_abc123", Some(&params)).await?;
 
 // Create a breaker
 let breaker = client
@@ -468,14 +465,13 @@ let breaker = client
             cooldown: None,
             metadata: None,
         },
-        None,
     )
     .await?;
 ```
 
 ### Request Options
 
-Per-request options for admin calls:
+Every method has a `_with_opts` variant that accepts per-request options:
 
 ```rust
 use tripswitch::admin::RequestOptions;
@@ -487,7 +483,7 @@ let opts = RequestOptions {
     headers: None,
 };
 
-let project = client.get_project("proj_abc123", Some(&opts)).await?;
+let project = client.get_project_with_opts("proj_abc123", Some(&opts)).await?;
 ```
 
 ### Admin Error Handling
@@ -495,7 +491,7 @@ let project = client.get_project("proj_abc123", Some(&opts)).await?;
 ```rust
 use tripswitch::admin::errors::AdminError;
 
-match client.get_project("proj_missing", None).await {
+match client.get_project("proj_missing").await {
     Ok(project) => { /* success */ }
     Err(e) if e.is_not_found() => println!("project not found"),
     Err(e) if e.is_rate_limited() => {

--- a/src/admin/breakers.rs
+++ b/src/admin/breakers.rs
@@ -7,6 +7,14 @@ impl AdminClient {
         &self,
         project_id: &str,
         params: Option<&ListParams>,
+    ) -> Result<ListBreakersResponse, AdminError> {
+        self.list_breakers_with_opts(project_id, params, None).await
+    }
+
+    pub async fn list_breakers_with_opts(
+        &self,
+        project_id: &str,
+        params: Option<&ListParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListBreakersResponse, AdminError> {
         let url = self.url(&format!("/v1/projects/{project_id}/breakers"));
@@ -24,6 +32,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         breaker_id: &str,
+    ) -> Result<Breaker, AdminError> {
+        self.get_breaker_with_opts(project_id, breaker_id, None)
+            .await
+    }
+
+    pub async fn get_breaker_with_opts(
+        &self,
+        project_id: &str,
+        breaker_id: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<Breaker, AdminError> {
         let builder = self
@@ -34,6 +51,14 @@ impl AdminClient {
     }
 
     pub async fn create_breaker(
+        &self,
+        project_id: &str,
+        input: &CreateBreakerInput,
+    ) -> Result<Breaker, AdminError> {
+        self.create_breaker_with_opts(project_id, input, None).await
+    }
+
+    pub async fn create_breaker_with_opts(
         &self,
         project_id: &str,
         input: &CreateBreakerInput,
@@ -52,6 +77,16 @@ impl AdminClient {
         project_id: &str,
         breaker_id: &str,
         input: &UpdateBreakerInput,
+    ) -> Result<Breaker, AdminError> {
+        self.update_breaker_with_opts(project_id, breaker_id, input, None)
+            .await
+    }
+
+    pub async fn update_breaker_with_opts(
+        &self,
+        project_id: &str,
+        breaker_id: &str,
+        input: &UpdateBreakerInput,
         opts: Option<&RequestOptions>,
     ) -> Result<Breaker, AdminError> {
         let builder = self
@@ -63,6 +98,15 @@ impl AdminClient {
     }
 
     pub async fn delete_breaker(
+        &self,
+        project_id: &str,
+        breaker_id: &str,
+    ) -> Result<(), AdminError> {
+        self.delete_breaker_with_opts(project_id, breaker_id, None)
+            .await
+    }
+
+    pub async fn delete_breaker_with_opts(
         &self,
         project_id: &str,
         breaker_id: &str,
@@ -79,6 +123,14 @@ impl AdminClient {
         &self,
         project_id: &str,
         input: &SyncBreakersInput,
+    ) -> Result<Vec<Breaker>, AdminError> {
+        self.sync_breakers_with_opts(project_id, input, None).await
+    }
+
+    pub async fn sync_breakers_with_opts(
+        &self,
+        project_id: &str,
+        input: &SyncBreakersInput,
         opts: Option<&RequestOptions>,
     ) -> Result<Vec<Breaker>, AdminError> {
         let builder = self
@@ -90,6 +142,15 @@ impl AdminClient {
     }
 
     pub async fn get_breaker_state(
+        &self,
+        project_id: &str,
+        breaker_id: &str,
+    ) -> Result<BreakerState, AdminError> {
+        self.get_breaker_state_with_opts(project_id, breaker_id, None)
+            .await
+    }
+
+    pub async fn get_breaker_state_with_opts(
         &self,
         project_id: &str,
         breaker_id: &str,
@@ -108,6 +169,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         input: &BatchGetBreakerStatesInput,
+    ) -> Result<Vec<BreakerState>, AdminError> {
+        self.batch_get_breaker_states_with_opts(project_id, input, None)
+            .await
+    }
+
+    pub async fn batch_get_breaker_states_with_opts(
+        &self,
+        project_id: &str,
+        input: &BatchGetBreakerStatesInput,
         opts: Option<&RequestOptions>,
     ) -> Result<Vec<BreakerState>, AdminError> {
         let builder = self
@@ -119,6 +189,16 @@ impl AdminClient {
     }
 
     pub async fn update_breaker_metadata(
+        &self,
+        project_id: &str,
+        breaker_id: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<Breaker, AdminError> {
+        self.update_breaker_metadata_with_opts(project_id, breaker_id, metadata, None)
+            .await
+    }
+
+    pub async fn update_breaker_metadata_with_opts(
         &self,
         project_id: &str,
         breaker_id: &str,

--- a/src/admin/events.rs
+++ b/src/admin/events.rs
@@ -7,6 +7,14 @@ impl AdminClient {
         &self,
         project_id: &str,
         params: Option<&ListEventsParams>,
+    ) -> Result<ListEventsResponse, AdminError> {
+        self.list_events_with_opts(project_id, params, None).await
+    }
+
+    pub async fn list_events_with_opts(
+        &self,
+        project_id: &str,
+        params: Option<&ListEventsParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListEventsResponse, AdminError> {
         let url = self.url(&format!("/v1/projects/{project_id}/events"));

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -283,7 +283,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let project = client.get_project("proj_123", None).await.unwrap();
+        let project = client.get_project("proj_123").await.unwrap();
 
         mock.assert();
         assert_eq!(project.id, "proj_123");
@@ -305,7 +305,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let resp = client.list_projects(None, None).await.unwrap();
+        let resp = client.list_projects(None).await.unwrap();
 
         mock.assert();
         assert_eq!(resp.data.len(), 2);
@@ -332,7 +332,7 @@ mod tests {
             name: "my-project".to_string(),
             description: None,
         };
-        let project = client.create_project(&input, None).await.unwrap();
+        let project = client.create_project(&input).await.unwrap();
 
         mock.assert();
         assert_eq!(project.name, "my-project");
@@ -358,10 +358,7 @@ mod tests {
             name: Some("Updated Name".to_string()),
             description: None,
         };
-        let project = client
-            .update_project("proj_123", &input, None)
-            .await
-            .unwrap();
+        let project = client.update_project("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert_eq!(project.name, "Updated Name");
@@ -379,7 +376,7 @@ mod tests {
 
         let client = test_client(&server);
         client
-            .delete_project("proj_123", "My Project", None)
+            .delete_project("proj_123", "My Project")
             .await
             .unwrap();
 
@@ -423,10 +420,7 @@ mod tests {
             cooldown: None,
             metadata: None,
         };
-        let breaker = client
-            .create_breaker("proj_123", &input, None)
-            .await
-            .unwrap();
+        let breaker = client.create_breaker("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert_eq!(breaker.id, "breaker_456");
@@ -460,7 +454,7 @@ mod tests {
             per_page: Some(10),
         };
         let resp = client
-            .list_breakers("proj_123", Some(&params), None)
+            .list_breakers("proj_123", Some(&params))
             .await
             .unwrap();
 
@@ -479,7 +473,7 @@ mod tests {
 
         let client = test_client(&server);
         client
-            .delete_breaker("proj_123", "breaker_456", None)
+            .delete_breaker("proj_123", "breaker_456")
             .await
             .unwrap();
 
@@ -511,10 +505,7 @@ mod tests {
             mode: Some(RouterMode::RoundRobin),
             metadata: None,
         };
-        let router = client
-            .create_router("proj_123", &input, None)
-            .await
-            .unwrap();
+        let router = client.create_router("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert_eq!(router.id, "router_789");
@@ -536,7 +527,7 @@ mod tests {
             breaker_id: "breaker_456".to_string(),
         };
         client
-            .link_breaker("proj_123", "router_789", &input, None)
+            .link_breaker("proj_123", "router_789", &input)
             .await
             .unwrap();
 
@@ -575,7 +566,7 @@ mod tests {
             enabled: None,
         };
         let channel = client
-            .create_notification_channel("proj_123", &input, None)
+            .create_notification_channel("proj_123", &input)
             .await
             .unwrap();
 
@@ -615,10 +606,7 @@ mod tests {
             breaker_id: Some("b_456".to_string()),
             ..Default::default()
         };
-        let resp = client
-            .list_events("proj_123", Some(&params), None)
-            .await
-            .unwrap();
+        let resp = client.list_events("proj_123", Some(&params)).await.unwrap();
 
         mock.assert();
         assert_eq!(resp.data.len(), 2);
@@ -640,7 +628,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let err = client.get_project("missing", None).await.unwrap_err();
+        let err = client.get_project("missing").await.unwrap_err();
 
         assert!(err.is_not_found());
         let api_err = err.api_error().unwrap();
@@ -663,7 +651,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let err = client.get_project("proj_123", None).await.unwrap_err();
+        let err = client.get_project("proj_123").await.unwrap_err();
 
         assert!(err.is_rate_limited());
         let api_err = err.api_error().unwrap();
@@ -682,7 +670,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let err = client.get_project("proj_123", None).await.unwrap_err();
+        let err = client.get_project("proj_123").await.unwrap_err();
         assert!(err.is_unauthorized());
     }
 
@@ -702,7 +690,7 @@ mod tests {
             name: "dup".to_string(),
             description: None,
         };
-        let err = client.create_project(&input, None).await.unwrap_err();
+        let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_conflict());
     }
 
@@ -722,7 +710,7 @@ mod tests {
             name: "".to_string(),
             description: None,
         };
-        let err = client.create_project(&input, None).await.unwrap_err();
+        let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_validation());
     }
 
@@ -738,7 +726,7 @@ mod tests {
         });
 
         let client = test_client(&server);
-        let err = client.get_project("proj_123", None).await.unwrap_err();
+        let err = client.get_project("proj_123").await.unwrap_err();
         assert!(err.is_server_fault());
     }
 
@@ -747,7 +735,7 @@ mod tests {
         let client = AdminClient::builder("eb_admin_test")
             .base_url("http://127.0.0.1:1")
             .build();
-        let err = client.get_project("proj_123", None).await.unwrap_err();
+        let err = client.get_project("proj_123").await.unwrap_err();
         assert!(err.is_transport());
     }
 
@@ -775,7 +763,10 @@ mod tests {
             timeout: None,
             headers: None,
         };
-        client.get_project("proj_123", Some(&opts)).await.unwrap();
+        client
+            .get_project_with_opts("proj_123", Some(&opts))
+            .await
+            .unwrap();
 
         mock.assert();
     }
@@ -801,7 +792,10 @@ mod tests {
             headers: Some(extra_headers),
             ..Default::default()
         };
-        client.get_project("proj_123", Some(&opts)).await.unwrap();
+        client
+            .get_project_with_opts("proj_123", Some(&opts))
+            .await
+            .unwrap();
 
         mock.assert();
     }
@@ -826,7 +820,7 @@ mod tests {
             ..Default::default()
         };
         let err = client
-            .get_project("proj_123", Some(&opts))
+            .get_project_with_opts("proj_123", Some(&opts))
             .await
             .unwrap_err();
         assert!(err.is_transport());
@@ -864,10 +858,7 @@ mod tests {
             cooldown: None,
             metadata: Some(serde_json::json!({"region": "us-east-1"})),
         };
-        let breaker = client
-            .create_breaker("proj_123", &input, None)
-            .await
-            .unwrap();
+        let breaker = client.create_breaker("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert!(breaker.metadata.is_some());
@@ -902,10 +893,7 @@ mod tests {
             cooldown: None,
             metadata: None,
         };
-        let breaker = client
-            .create_breaker("proj_123", &input, None)
-            .await
-            .unwrap();
+        let breaker = client.create_breaker("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert!(breaker.metadata.is_none());

--- a/src/admin/notifications.rs
+++ b/src/admin/notifications.rs
@@ -7,6 +7,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         params: Option<&ListParams>,
+    ) -> Result<ListNotificationChannelsResponse, AdminError> {
+        self.list_notification_channels_with_opts(project_id, params, None)
+            .await
+    }
+
+    pub async fn list_notification_channels_with_opts(
+        &self,
+        project_id: &str,
+        params: Option<&ListParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListNotificationChannelsResponse, AdminError> {
         let url = self.url(&format!("/v1/projects/{project_id}/notification-channels"));
@@ -21,6 +30,15 @@ impl AdminClient {
     }
 
     pub async fn get_notification_channel(
+        &self,
+        project_id: &str,
+        channel_id: &str,
+    ) -> Result<NotificationChannel, AdminError> {
+        self.get_notification_channel_with_opts(project_id, channel_id, None)
+            .await
+    }
+
+    pub async fn get_notification_channel_with_opts(
         &self,
         project_id: &str,
         channel_id: &str,
@@ -39,6 +57,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         input: &CreateNotificationChannelInput,
+    ) -> Result<NotificationChannel, AdminError> {
+        self.create_notification_channel_with_opts(project_id, input, None)
+            .await
+    }
+
+    pub async fn create_notification_channel_with_opts(
+        &self,
+        project_id: &str,
+        input: &CreateNotificationChannelInput,
         opts: Option<&RequestOptions>,
     ) -> Result<NotificationChannel, AdminError> {
         let builder = self
@@ -50,6 +77,16 @@ impl AdminClient {
     }
 
     pub async fn update_notification_channel(
+        &self,
+        project_id: &str,
+        channel_id: &str,
+        input: &UpdateNotificationChannelInput,
+    ) -> Result<NotificationChannel, AdminError> {
+        self.update_notification_channel_with_opts(project_id, channel_id, input, None)
+            .await
+    }
+
+    pub async fn update_notification_channel_with_opts(
         &self,
         project_id: &str,
         channel_id: &str,
@@ -70,6 +107,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         channel_id: &str,
+    ) -> Result<(), AdminError> {
+        self.delete_notification_channel_with_opts(project_id, channel_id, None)
+            .await
+    }
+
+    pub async fn delete_notification_channel_with_opts(
+        &self,
+        project_id: &str,
+        channel_id: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<(), AdminError> {
         let builder = self
@@ -82,6 +128,15 @@ impl AdminClient {
     }
 
     pub async fn test_notification_channel(
+        &self,
+        project_id: &str,
+        channel_id: &str,
+    ) -> Result<(), AdminError> {
+        self.test_notification_channel_with_opts(project_id, channel_id, None)
+            .await
+    }
+
+    pub async fn test_notification_channel_with_opts(
         &self,
         project_id: &str,
         channel_id: &str,

--- a/src/admin/project_keys.rs
+++ b/src/admin/project_keys.rs
@@ -6,6 +6,13 @@ impl AdminClient {
     pub async fn list_project_keys(
         &self,
         project_id: &str,
+    ) -> Result<ListProjectKeysResponse, AdminError> {
+        self.list_project_keys_with_opts(project_id, None).await
+    }
+
+    pub async fn list_project_keys_with_opts(
+        &self,
+        project_id: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<ListProjectKeysResponse, AdminError> {
         let builder = self
@@ -16,6 +23,15 @@ impl AdminClient {
     }
 
     pub async fn create_project_key(
+        &self,
+        project_id: &str,
+        input: &CreateProjectKeyInput,
+    ) -> Result<CreateProjectKeyResponse, AdminError> {
+        self.create_project_key_with_opts(project_id, input, None)
+            .await
+    }
+
+    pub async fn create_project_key_with_opts(
         &self,
         project_id: &str,
         input: &CreateProjectKeyInput,
@@ -30,6 +46,15 @@ impl AdminClient {
     }
 
     pub async fn delete_project_key(
+        &self,
+        project_id: &str,
+        key_id: &str,
+    ) -> Result<(), AdminError> {
+        self.delete_project_key_with_opts(project_id, key_id, None)
+            .await
+    }
+
+    pub async fn delete_project_key_with_opts(
         &self,
         project_id: &str,
         key_id: &str,

--- a/src/admin/projects.rs
+++ b/src/admin/projects.rs
@@ -6,6 +6,13 @@ impl AdminClient {
     pub async fn list_projects(
         &self,
         params: Option<&ListParams>,
+    ) -> Result<ListProjectsResponse, AdminError> {
+        self.list_projects_with_opts(params, None).await
+    }
+
+    pub async fn list_projects_with_opts(
+        &self,
+        params: Option<&ListParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListProjectsResponse, AdminError> {
         let url = self.url("/v1/projects");
@@ -19,7 +26,11 @@ impl AdminClient {
         self.do_request(builder, opts).await
     }
 
-    pub async fn get_project(
+    pub async fn get_project(&self, project_id: &str) -> Result<Project, AdminError> {
+        self.get_project_with_opts(project_id, None).await
+    }
+
+    pub async fn get_project_with_opts(
         &self,
         project_id: &str,
         opts: Option<&RequestOptions>,
@@ -31,7 +42,11 @@ impl AdminClient {
         self.do_request(builder, opts).await
     }
 
-    pub async fn create_project(
+    pub async fn create_project(&self, input: &CreateProjectInput) -> Result<Project, AdminError> {
+        self.create_project_with_opts(input, None).await
+    }
+
+    pub async fn create_project_with_opts(
         &self,
         input: &CreateProjectInput,
         opts: Option<&RequestOptions>,
@@ -45,6 +60,14 @@ impl AdminClient {
     }
 
     pub async fn update_project(
+        &self,
+        project_id: &str,
+        input: &UpdateProjectInput,
+    ) -> Result<Project, AdminError> {
+        self.update_project_with_opts(project_id, input, None).await
+    }
+
+    pub async fn update_project_with_opts(
         &self,
         project_id: &str,
         input: &UpdateProjectInput,
@@ -62,6 +85,15 @@ impl AdminClient {
         &self,
         project_id: &str,
         confirm_name: &str,
+    ) -> Result<(), AdminError> {
+        self.delete_project_with_opts(project_id, confirm_name, None)
+            .await
+    }
+
+    pub async fn delete_project_with_opts(
+        &self,
+        project_id: &str,
+        confirm_name: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<(), AdminError> {
         let builder = self
@@ -73,6 +105,13 @@ impl AdminClient {
     }
 
     pub async fn rotate_ingest_secret(
+        &self,
+        project_id: &str,
+    ) -> Result<IngestSecretRotation, AdminError> {
+        self.rotate_ingest_secret_with_opts(project_id, None).await
+    }
+
+    pub async fn rotate_ingest_secret_with_opts(
         &self,
         project_id: &str,
         opts: Option<&RequestOptions>,

--- a/src/admin/routers.rs
+++ b/src/admin/routers.rs
@@ -7,6 +7,14 @@ impl AdminClient {
         &self,
         project_id: &str,
         params: Option<&ListParams>,
+    ) -> Result<ListRoutersResponse, AdminError> {
+        self.list_routers_with_opts(project_id, params, None).await
+    }
+
+    pub async fn list_routers_with_opts(
+        &self,
+        project_id: &str,
+        params: Option<&ListParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListRoutersResponse, AdminError> {
         let url = self.url(&format!("/v1/projects/{project_id}/routers"));
@@ -24,6 +32,14 @@ impl AdminClient {
         &self,
         project_id: &str,
         router_id: &str,
+    ) -> Result<Router, AdminError> {
+        self.get_router_with_opts(project_id, router_id, None).await
+    }
+
+    pub async fn get_router_with_opts(
+        &self,
+        project_id: &str,
+        router_id: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<Router, AdminError> {
         let builder = self
@@ -34,6 +50,14 @@ impl AdminClient {
     }
 
     pub async fn create_router(
+        &self,
+        project_id: &str,
+        input: &CreateRouterInput,
+    ) -> Result<Router, AdminError> {
+        self.create_router_with_opts(project_id, input, None).await
+    }
+
+    pub async fn create_router_with_opts(
         &self,
         project_id: &str,
         input: &CreateRouterInput,
@@ -52,6 +76,16 @@ impl AdminClient {
         project_id: &str,
         router_id: &str,
         input: &UpdateRouterInput,
+    ) -> Result<Router, AdminError> {
+        self.update_router_with_opts(project_id, router_id, input, None)
+            .await
+    }
+
+    pub async fn update_router_with_opts(
+        &self,
+        project_id: &str,
+        router_id: &str,
+        input: &UpdateRouterInput,
         opts: Option<&RequestOptions>,
     ) -> Result<Router, AdminError> {
         let builder = self
@@ -62,7 +96,12 @@ impl AdminClient {
         self.do_request(builder, opts).await
     }
 
-    pub async fn delete_router(
+    pub async fn delete_router(&self, project_id: &str, router_id: &str) -> Result<(), AdminError> {
+        self.delete_router_with_opts(project_id, router_id, None)
+            .await
+    }
+
+    pub async fn delete_router_with_opts(
         &self,
         project_id: &str,
         router_id: &str,
@@ -76,6 +115,16 @@ impl AdminClient {
     }
 
     pub async fn link_breaker(
+        &self,
+        project_id: &str,
+        router_id: &str,
+        input: &LinkBreakerInput,
+    ) -> Result<(), AdminError> {
+        self.link_breaker_with_opts(project_id, router_id, input, None)
+            .await
+    }
+
+    pub async fn link_breaker_with_opts(
         &self,
         project_id: &str,
         router_id: &str,
@@ -97,6 +146,16 @@ impl AdminClient {
         project_id: &str,
         router_id: &str,
         breaker_id: &str,
+    ) -> Result<(), AdminError> {
+        self.unlink_breaker_with_opts(project_id, router_id, breaker_id, None)
+            .await
+    }
+
+    pub async fn unlink_breaker_with_opts(
+        &self,
+        project_id: &str,
+        router_id: &str,
+        breaker_id: &str,
         opts: Option<&RequestOptions>,
     ) -> Result<(), AdminError> {
         let builder = self
@@ -109,6 +168,16 @@ impl AdminClient {
     }
 
     pub async fn update_router_metadata(
+        &self,
+        project_id: &str,
+        router_id: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<Router, AdminError> {
+        self.update_router_metadata_with_opts(project_id, router_id, metadata, None)
+            .await
+    }
+
+    pub async fn update_router_metadata_with_opts(
         &self,
         project_id: &str,
         router_id: &str,

--- a/tests/admin_integration.rs
+++ b/tests/admin_integration.rs
@@ -18,7 +18,7 @@ fn project_id() -> String {
 async fn test_get_project() {
     let client = admin_client();
     let pid = project_id();
-    let project = client.get_project(&pid, None).await.unwrap();
+    let project = client.get_project(&pid).await.unwrap();
     assert_eq!(project.id, pid);
 }
 
@@ -27,7 +27,7 @@ async fn test_get_project() {
 async fn test_list_breakers() {
     let client = admin_client();
     let pid = project_id();
-    let resp = client.list_breakers(&pid, None, None).await.unwrap();
+    let resp = client.list_breakers(&pid, None).await.unwrap();
     assert!(resp.total >= 0);
 }
 
@@ -36,7 +36,7 @@ async fn test_list_breakers() {
 async fn test_list_routers() {
     let client = admin_client();
     let pid = project_id();
-    let resp = client.list_routers(&pid, None, None).await.unwrap();
+    let resp = client.list_routers(&pid, None).await.unwrap();
     assert!(resp.total >= 0);
 }
 
@@ -45,7 +45,7 @@ async fn test_list_routers() {
 async fn test_list_events() {
     let client = admin_client();
     let pid = project_id();
-    let resp = client.list_events(&pid, None, None).await.unwrap();
+    let resp = client.list_events(&pid, None).await.unwrap();
     assert!(resp.total >= 0);
 }
 
@@ -54,10 +54,7 @@ async fn test_list_events() {
 async fn test_list_notification_channels() {
     let client = admin_client();
     let pid = project_id();
-    let resp = client
-        .list_notification_channels(&pid, None, None)
-        .await
-        .unwrap();
+    let resp = client.list_notification_channels(&pid, None).await.unwrap();
     assert!(resp.total >= 0);
 }
 
@@ -82,11 +79,11 @@ async fn test_breaker_crud() {
         cooldown: None,
         metadata: None,
     };
-    let breaker = client.create_breaker(&pid, &input, None).await.unwrap();
+    let breaker = client.create_breaker(&pid, &input).await.unwrap();
     assert_eq!(breaker.metric, "error_rate");
 
     // Get
-    let fetched = client.get_breaker(&pid, &breaker.id, None).await.unwrap();
+    let fetched = client.get_breaker(&pid, &breaker.id).await.unwrap();
     assert_eq!(fetched.id, breaker.id);
 
     // Update
@@ -104,18 +101,15 @@ async fn test_breaker_crud() {
         metadata: None,
     };
     let updated = client
-        .update_breaker(&pid, &breaker.id, &update, None)
+        .update_breaker(&pid, &breaker.id, &update)
         .await
         .unwrap();
     assert_eq!(updated.description.as_deref(), Some("updated description"));
 
     // Delete
-    client
-        .delete_breaker(&pid, &breaker.id, None)
-        .await
-        .unwrap();
+    client.delete_breaker(&pid, &breaker.id).await.unwrap();
 
     // Verify deleted
-    let result = client.get_breaker(&pid, &breaker.id, None).await;
+    let result = client.get_breaker(&pid, &breaker.id).await;
     assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
- Split every admin method into a clean signature and a `_with_opts` variant
- Clean methods delegate to `_with_opts(..., None)`, removing trailing `None` from all call sites
- Updated all unit tests, integration tests, and README examples

## Test plan
- [x] All 146 unit tests pass
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo fmt --check` — clean