### PR TITLE
Add feature parity with Go and Python SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,30 @@ ExecuteOptions::new()
     })))
 ```
 
+### Deferred Metrics
+
+Use `execute_with_deferred` to compute metrics from the task's result:
+
+```rust
+let response = client
+    .execute_with_deferred(
+        || async { fetch_items().await },
+        ExecuteOptions::new()
+            .router("my-router")
+            .metric("latency", MetricValue::Latency),
+        |result| {
+            let mut m = HashMap::new();
+            if let Ok(items) = result {
+                m.insert("item_count".to_string(), items.len() as f64);
+            }
+            m
+        },
+    )
+    .await?;
+```
+
+The closure receives `Result<&T, &E>` and returns a `HashMap<String, f64>` of additional metrics to report alongside the standard ones. Panics in the closure are caught and logged.
+
 ### close
 
 ```rust
@@ -238,10 +262,14 @@ Returns a snapshot of SDK health metrics:
 
 ```rust
 pub struct SdkStats {
-    pub dropped_samples: u64,   // Samples dropped due to buffer overflow
-    pub buffer_capacity: usize,  // Channel buffer capacity
-    pub sse_connected: bool,    // SSE connection status
-    pub sse_reconnects: u64,    // Count of SSE reconnections
+    pub dropped_samples: u64,                              // Samples dropped due to buffer overflow
+    pub buffer_capacity: usize,                            // Channel buffer capacity
+    pub sse_connected: bool,                               // SSE connection status
+    pub sse_reconnects: u64,                               // Count of SSE reconnections
+    pub flush_failures: u64,                               // Batches dropped after retry exhaustion
+    pub last_successful_flush: Option<DateTime<Utc>>,      // Timestamp of last successful batch send
+    pub last_sse_event: Option<DateTime<Utc>>,             // Timestamp of last SSE event received
+    pub cached_breakers: usize,                            // Number of breakers in local state cache
 }
 ```
 
@@ -485,6 +513,26 @@ let opts = RequestOptions {
 
 let project = client.get_project_with_opts("proj_abc123", Some(&opts)).await?;
 ```
+
+### Pagination
+
+Every list method returns a `Page<T>` with page metadata. For iterating across all pages, use the `_pager` methods:
+
+```rust
+use tripswitch::admin::pager::Pager;
+
+// Iterate item-by-item across all pages
+let mut pager = client.list_breakers_pager("proj_abc123", None);
+while let Some(breaker) = pager.next().await? {
+    println!("{}: {:?}", breaker.name, breaker.metric);
+}
+
+// Or collect everything at once
+let mut pager = client.list_routers_pager("proj_abc123", Some(50));
+let all_routers = pager.collect_all().await?;
+```
+
+Available pagers: `list_projects_pager`, `list_breakers_pager`, `list_routers_pager`, `list_notification_channels_pager`, `list_events_pager`.
 
 ### Admin Error Handling
 

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,9 +1,11 @@
 pub mod errors;
+pub mod pager;
 pub mod types;
 
 mod breakers;
 mod events;
 mod notifications;
+mod pagers;
 mod project_keys;
 mod projects;
 mod routers;
@@ -897,5 +899,63 @@ mod tests {
 
         mock.assert();
         assert!(breaker.metadata.is_none());
+    }
+
+    // ── Pager Tests ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn pager_iterates_across_pages() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/projects")
+                .query_param("page", "1")
+                .query_param("per_page", "2");
+            then.status(200).json_body(json!({
+                "data": [
+                    {"id":"p1","name":"P1","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},
+                    {"id":"p2","name":"P2","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}
+                ],
+                "page": 1, "per_page": 2, "total": 3, "total_pages": 2
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/projects")
+                .query_param("page", "2")
+                .query_param("per_page", "2");
+            then.status(200).json_body(json!({
+                "data": [
+                    {"id":"p3","name":"P3","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}
+                ],
+                "page": 2, "per_page": 2, "total": 3, "total_pages": 2
+            }));
+        });
+
+        let client = test_client(&server);
+        let mut pager = client.list_projects_pager(Some(2));
+        let all = pager.collect_all().await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].id, "p1");
+        assert_eq!(all[2].id, "p3");
+    }
+
+    #[tokio::test]
+    async fn pager_empty_result() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/projects/proj_123/breakers")
+                .query_param("page", "1");
+            then.status(200).json_body(json!({
+                "data": [],
+                "page": 1, "per_page": 100, "total": 0, "total_pages": 0
+            }));
+        });
+
+        let client = test_client(&server);
+        let mut pager = client.list_breakers_pager("proj_123", None);
+        let result = pager.next().await.unwrap();
+        assert!(result.is_none());
     }
 }

--- a/src/admin/pager.rs
+++ b/src/admin/pager.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -19,8 +20,7 @@ type FetchFn<T> = Box<
 pub struct Pager<T> {
     fetch: FetchFn<T>,
     current_page: i64,
-    total_pages: Option<i64>,
-    buffer: Vec<T>,
+    buffer: VecDeque<T>,
     done: bool,
 }
 
@@ -29,17 +29,16 @@ impl<T: Send + 'static> Pager<T> {
         Self {
             fetch,
             current_page: 1,
-            total_pages: None,
-            buffer: Vec::new(),
+            buffer: VecDeque::new(),
             done: false,
         }
     }
 
-    /// Returns the next item, fetching the next page when the buffer is empty.
+    /// Returns the next item, fetching the next page when the buffer is exhausted.
     /// Returns `Ok(None)` when all pages have been exhausted.
     pub async fn next(&mut self) -> Result<Option<T>, AdminError> {
         loop {
-            if let Some(item) = self.buffer.pop() {
+            if let Some(item) = self.buffer.pop_front() {
                 return Ok(Some(item));
             }
 
@@ -48,12 +47,7 @@ impl<T: Send + 'static> Pager<T> {
             }
 
             let page = (self.fetch)(self.current_page).await?;
-            self.total_pages = Some(page.total_pages);
-
-            // Reverse so we can pop from the end in order
-            let mut items = page.data;
-            items.reverse();
-            self.buffer = items;
+            self.buffer = page.data.into();
 
             if self.current_page >= page.total_pages || self.buffer.is_empty() {
                 self.done = true;

--- a/src/admin/pager.rs
+++ b/src/admin/pager.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use super::errors::AdminError;
+use super::types::Page;
+
+type FetchFn<T> = Box<
+    dyn Fn(i64) -> Pin<Box<dyn Future<Output = Result<Page<T>, AdminError>> + Send>> + Send + Sync,
+>;
+
+/// An async page iterator for admin list endpoints.
+///
+/// ```ignore
+/// let mut pager = client.list_breakers_pager("proj_123", None);
+/// while let Some(breaker) = pager.next().await? {
+///     println!("{}", breaker.name);
+/// }
+/// ```
+pub struct Pager<T> {
+    fetch: FetchFn<T>,
+    current_page: i64,
+    total_pages: Option<i64>,
+    buffer: Vec<T>,
+    done: bool,
+}
+
+impl<T: Send + 'static> Pager<T> {
+    pub(crate) fn new(fetch: FetchFn<T>) -> Self {
+        Self {
+            fetch,
+            current_page: 1,
+            total_pages: None,
+            buffer: Vec::new(),
+            done: false,
+        }
+    }
+
+    /// Returns the next item, fetching the next page when the buffer is empty.
+    /// Returns `Ok(None)` when all pages have been exhausted.
+    pub async fn next(&mut self) -> Result<Option<T>, AdminError> {
+        loop {
+            if let Some(item) = self.buffer.pop() {
+                return Ok(Some(item));
+            }
+
+            if self.done {
+                return Ok(None);
+            }
+
+            let page = (self.fetch)(self.current_page).await?;
+            self.total_pages = Some(page.total_pages);
+
+            // Reverse so we can pop from the end in order
+            let mut items = page.data;
+            items.reverse();
+            self.buffer = items;
+
+            if self.current_page >= page.total_pages || self.buffer.is_empty() {
+                self.done = true;
+            }
+            self.current_page += 1;
+        }
+    }
+
+    /// Collect all remaining items into a Vec.
+    pub async fn collect_all(&mut self) -> Result<Vec<T>, AdminError> {
+        let mut all = Vec::new();
+        while let Some(item) = self.next().await? {
+            all.push(item);
+        }
+        Ok(all)
+    }
+}

--- a/src/admin/pagers.rs
+++ b/src/admin/pagers.rs
@@ -1,0 +1,107 @@
+use super::pager::Pager;
+use super::types::*;
+use super::AdminClient;
+
+impl AdminClient {
+    /// Create a pager that iterates over all projects.
+    pub fn list_projects_pager(&self, per_page: Option<i64>) -> Pager<Project> {
+        let client = self.clone();
+        let pp = per_page.unwrap_or(100);
+        Pager::new(Box::new(move |page| {
+            let client = client.clone();
+            Box::pin(async move {
+                let params = ListParams {
+                    page: Some(page),
+                    per_page: Some(pp),
+                };
+                client.list_projects(Some(&params)).await
+            })
+        }))
+    }
+
+    /// Create a pager that iterates over all breakers in a project.
+    pub fn list_breakers_pager(
+        &self,
+        project_id: impl Into<String>,
+        per_page: Option<i64>,
+    ) -> Pager<Breaker> {
+        let client = self.clone();
+        let pid = project_id.into();
+        let pp = per_page.unwrap_or(100);
+        Pager::new(Box::new(move |page| {
+            let client = client.clone();
+            let pid = pid.clone();
+            Box::pin(async move {
+                let params = ListParams {
+                    page: Some(page),
+                    per_page: Some(pp),
+                };
+                client.list_breakers(&pid, Some(&params)).await
+            })
+        }))
+    }
+
+    /// Create a pager that iterates over all routers in a project.
+    pub fn list_routers_pager(
+        &self,
+        project_id: impl Into<String>,
+        per_page: Option<i64>,
+    ) -> Pager<Router> {
+        let client = self.clone();
+        let pid = project_id.into();
+        let pp = per_page.unwrap_or(100);
+        Pager::new(Box::new(move |page| {
+            let client = client.clone();
+            let pid = pid.clone();
+            Box::pin(async move {
+                let params = ListParams {
+                    page: Some(page),
+                    per_page: Some(pp),
+                };
+                client.list_routers(&pid, Some(&params)).await
+            })
+        }))
+    }
+
+    /// Create a pager that iterates over all notification channels in a project.
+    pub fn list_notification_channels_pager(
+        &self,
+        project_id: impl Into<String>,
+        per_page: Option<i64>,
+    ) -> Pager<NotificationChannel> {
+        let client = self.clone();
+        let pid = project_id.into();
+        let pp = per_page.unwrap_or(100);
+        Pager::new(Box::new(move |page| {
+            let client = client.clone();
+            let pid = pid.clone();
+            Box::pin(async move {
+                let params = ListParams {
+                    page: Some(page),
+                    per_page: Some(pp),
+                };
+                client.list_notification_channels(&pid, Some(&params)).await
+            })
+        }))
+    }
+
+    /// Create a pager that iterates over all events in a project.
+    pub fn list_events_pager(
+        &self,
+        project_id: impl Into<String>,
+        params: Option<ListEventsParams>,
+        per_page: Option<i64>,
+    ) -> Pager<Event> {
+        let client = self.clone();
+        let pid = project_id.into();
+        let pp = per_page.unwrap_or(100);
+        Pager::new(Box::new(move |page| {
+            let client = client.clone();
+            let pid = pid.clone();
+            let mut p = params.clone().unwrap_or_default();
+            p.page = Some(page);
+            p.per_page = Some(pp);
+            Box::pin(async move { client.list_events(&pid, Some(&p)).await })
+        }))
+    }
+}

--- a/src/admin/pagers.rs
+++ b/src/admin/pagers.rs
@@ -2,6 +2,27 @@ use super::pager::Pager;
 use super::types::*;
 use super::AdminClient;
 
+macro_rules! project_pager {
+    ($method:ident, $list:ident, $T:ty) => {
+        pub fn $method(&self, project_id: impl Into<String>, per_page: Option<i64>) -> Pager<$T> {
+            let client = self.clone();
+            let pid = project_id.into();
+            let pp = per_page.unwrap_or(100);
+            Pager::new(Box::new(move |page| {
+                let client = client.clone();
+                let pid = pid.clone();
+                Box::pin(async move {
+                    let params = ListParams {
+                        page: Some(page),
+                        per_page: Some(pp),
+                    };
+                    client.$list(&pid, Some(&params)).await
+                })
+            }))
+        }
+    };
+}
+
 impl AdminClient {
     /// Create a pager that iterates over all projects.
     pub fn list_projects_pager(&self, per_page: Option<i64>) -> Pager<Project> {
@@ -19,71 +40,13 @@ impl AdminClient {
         }))
     }
 
-    /// Create a pager that iterates over all breakers in a project.
-    pub fn list_breakers_pager(
-        &self,
-        project_id: impl Into<String>,
-        per_page: Option<i64>,
-    ) -> Pager<Breaker> {
-        let client = self.clone();
-        let pid = project_id.into();
-        let pp = per_page.unwrap_or(100);
-        Pager::new(Box::new(move |page| {
-            let client = client.clone();
-            let pid = pid.clone();
-            Box::pin(async move {
-                let params = ListParams {
-                    page: Some(page),
-                    per_page: Some(pp),
-                };
-                client.list_breakers(&pid, Some(&params)).await
-            })
-        }))
-    }
-
-    /// Create a pager that iterates over all routers in a project.
-    pub fn list_routers_pager(
-        &self,
-        project_id: impl Into<String>,
-        per_page: Option<i64>,
-    ) -> Pager<Router> {
-        let client = self.clone();
-        let pid = project_id.into();
-        let pp = per_page.unwrap_or(100);
-        Pager::new(Box::new(move |page| {
-            let client = client.clone();
-            let pid = pid.clone();
-            Box::pin(async move {
-                let params = ListParams {
-                    page: Some(page),
-                    per_page: Some(pp),
-                };
-                client.list_routers(&pid, Some(&params)).await
-            })
-        }))
-    }
-
-    /// Create a pager that iterates over all notification channels in a project.
-    pub fn list_notification_channels_pager(
-        &self,
-        project_id: impl Into<String>,
-        per_page: Option<i64>,
-    ) -> Pager<NotificationChannel> {
-        let client = self.clone();
-        let pid = project_id.into();
-        let pp = per_page.unwrap_or(100);
-        Pager::new(Box::new(move |page| {
-            let client = client.clone();
-            let pid = pid.clone();
-            Box::pin(async move {
-                let params = ListParams {
-                    page: Some(page),
-                    per_page: Some(pp),
-                };
-                client.list_notification_channels(&pid, Some(&params)).await
-            })
-        }))
-    }
+    project_pager!(list_breakers_pager, list_breakers, Breaker);
+    project_pager!(list_routers_pager, list_routers, Router);
+    project_pager!(
+        list_notification_channels_pager,
+        list_notification_channels,
+        NotificationChannel
+    );
 
     /// Create a pager that iterates over all events in a project.
     pub fn list_events_pager(

--- a/src/client.rs
+++ b/src/client.rs
@@ -343,8 +343,10 @@ impl Client {
         E: std::error::Error + Send + 'static,
         Fut: Future<Output = Result<T, E>>,
     {
-        self.execute_inner::<T, E, Fut, fn(Result<&T, &E>) -> HashMap<String, f64>>(
-            task, opts, None,
+        self.execute_inner(
+            task,
+            opts,
+            None::<fn(Result<&T, &E>) -> HashMap<String, f64>>,
         )
         .await
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,6 +17,14 @@ use crate::types::*;
 
 const DEFAULT_BASE_URL: &str = "https://api.tripswitch.dev";
 
+fn ms_to_datetime(ms: u64) -> Option<chrono::DateTime<chrono::Utc>> {
+    if ms == 0 {
+        None
+    } else {
+        chrono::DateTime::from_timestamp_millis(ms as i64)
+    }
+}
+
 // ── ExecuteOptions ─────────────────────────────────────────────────
 
 type BreakerSelector = Box<dyn FnOnce(&[BreakerMeta]) -> Vec<String> + Send>;
@@ -306,6 +314,25 @@ impl Client {
         ClientBuilder::new(project_id)
     }
 
+    /// Execute a task, gated by breaker state, with deferred metrics computed from the result.
+    ///
+    /// The `deferred_metrics` closure receives the task result (or error) and returns
+    /// additional metrics to report. This is useful for extracting metrics from the
+    /// response (e.g., response size, item count) that aren't known until after execution.
+    pub async fn execute_with_deferred<T, E, Fut, F>(
+        &self,
+        task: impl FnOnce() -> Fut,
+        opts: ExecuteOptions,
+        deferred_metrics: F,
+    ) -> Result<T, ExecuteError<E>>
+    where
+        E: std::error::Error + Send + 'static,
+        Fut: Future<Output = Result<T, E>>,
+        F: FnOnce(Result<&T, &E>) -> HashMap<String, f64>,
+    {
+        self.execute_inner(task, opts, Some(deferred_metrics)).await
+    }
+
     /// Execute a task, gated by breaker state.
     pub async fn execute<T, E, Fut>(
         &self,
@@ -315,6 +342,23 @@ impl Client {
     where
         E: std::error::Error + Send + 'static,
         Fut: Future<Output = Result<T, E>>,
+    {
+        self.execute_inner::<T, E, Fut, fn(Result<&T, &E>) -> HashMap<String, f64>>(
+            task, opts, None,
+        )
+        .await
+    }
+
+    async fn execute_inner<T, E, Fut, F>(
+        &self,
+        task: impl FnOnce() -> Fut,
+        opts: ExecuteOptions,
+        deferred_metrics: Option<F>,
+    ) -> Result<T, ExecuteError<E>>
+    where
+        E: std::error::Error + Send + 'static,
+        Fut: Future<Output = Result<T, E>>,
+        F: FnOnce(Result<&T, &E>) -> HashMap<String, f64>,
     {
         // 1. Validate no conflicting options
         if opts.breakers.is_some() && opts.select_breakers.is_some() {
@@ -410,14 +454,18 @@ impl Client {
 
         // 7. Resolve metrics and emit samples
         if let Some(ref rid) = router_id {
+            let mut merged_tags = self.inner.global_tags.clone().unwrap_or_default();
+            if let Some(call_tags) = opts.tags {
+                merged_tags.extend(call_tags);
+            }
+            let ts_ms = chrono::Utc::now().timestamp_millis();
+            let tags_for_sample = if merged_tags.is_empty() {
+                None
+            } else {
+                Some(&merged_tags)
+            };
+
             if let Some(metrics) = opts.metrics {
-                let mut merged_tags = self.inner.global_tags.clone().unwrap_or_default();
-                if let Some(call_tags) = opts.tags {
-                    merged_tags.extend(call_tags);
-                }
-
-                let ts_ms = chrono::Utc::now().timestamp_millis();
-
                 for (metric_name, metric_val) in metrics {
                     if metric_name.is_empty() {
                         continue;
@@ -436,32 +484,59 @@ impl Client {
                         }
                     };
 
-                    let entry = ReportEntry {
+                    self.emit_sample(ReportEntry {
                         router_id: rid.clone(),
                         metric: metric_name,
                         ts_ms,
                         value,
                         ok,
-                        tags: if merged_tags.is_empty() {
-                            None
-                        } else {
-                            Some(merged_tags.clone())
-                        },
+                        tags: tags_for_sample.cloned(),
                         trace_id: opts.trace_id.clone(),
-                    };
+                    });
+                }
+            }
 
-                    if self.inner.ingest.tx.try_send(entry).is_err() {
-                        self.inner
-                            .ingest
-                            .stats
-                            .dropped_samples
-                            .fetch_add(1, Ordering::Relaxed);
+            // 8. Deferred metrics — compute from task result
+            if let Some(deferred) = deferred_metrics {
+                let deferred_result =
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        deferred(result.as_ref())
+                    }));
+                match deferred_result {
+                    Ok(extra_metrics) => {
+                        for (metric_name, value) in extra_metrics {
+                            if metric_name.is_empty() {
+                                continue;
+                            }
+                            self.emit_sample(ReportEntry {
+                                router_id: rid.clone(),
+                                metric: metric_name,
+                                ts_ms,
+                                value,
+                                ok,
+                                tags: tags_for_sample.cloned(),
+                                trace_id: opts.trace_id.clone(),
+                            });
+                        }
+                    }
+                    Err(_) => {
+                        warn!("deferred_metrics closure panicked");
                     }
                 }
             }
         }
 
         result.map_err(ExecuteError::Task)
+    }
+
+    fn emit_sample(&self, entry: ReportEntry) {
+        if self.inner.ingest.tx.try_send(entry).is_err() {
+            self.inner
+                .ingest
+                .stats
+                .dropped_samples
+                .fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// Report a sample directly without executing a task.
@@ -576,6 +651,22 @@ impl Client {
 
     /// Get SDK statistics.
     pub fn stats(&self) -> SdkStats {
+        let last_flush_ms = self
+            .inner
+            .ingest
+            .stats
+            .last_successful_flush_ms
+            .load(Ordering::Relaxed);
+        let last_event_ms = self.inner.sse.stats.last_event_ms.load(Ordering::Relaxed);
+
+        let cached_breakers = self
+            .inner
+            .sse
+            .states
+            .try_read()
+            .map(|s| s.len())
+            .unwrap_or(0);
+
         SdkStats {
             dropped_samples: self
                 .inner
@@ -586,6 +677,15 @@ impl Client {
             buffer_capacity: self.inner.ingest.buffer_capacity(),
             sse_connected: self.inner.sse.stats.connected.load(Ordering::Relaxed),
             sse_reconnects: self.inner.sse.stats.reconnects.load(Ordering::Relaxed),
+            flush_failures: self
+                .inner
+                .ingest
+                .stats
+                .flush_failures
+                .load(Ordering::Relaxed),
+            last_successful_flush: ms_to_datetime(last_flush_ms),
+            last_sse_event: ms_to_datetime(last_event_ms),
+            cached_breakers,
         }
     }
 
@@ -637,6 +737,7 @@ mod tests {
             stats: SseStats {
                 connected: Arc::new(AtomicBool::new(true)),
                 reconnects: Arc::new(AtomicU64::new(0)),
+                last_event_ms: Arc::new(AtomicU64::new(0)),
             },
             task_handle: tokio::spawn(async {}),
         };
@@ -645,6 +746,8 @@ mod tests {
             tx,
             stats: IngestStats {
                 dropped_samples: Arc::new(AtomicU64::new(0)),
+                flush_failures: Arc::new(AtomicU64::new(0)),
+                last_successful_flush_ms: Arc::new(AtomicU64::new(0)),
             },
             task_handle: tokio::spawn(async {}),
         };
@@ -1266,6 +1369,86 @@ mod tests {
     // ── stats ──────────────────────────────────────────────────────
 
     #[tokio::test]
+    async fn execute_with_deferred_emits_extra_metrics() {
+        let (client, mut rx) = new_test_client();
+
+        let result = client
+            .execute_with_deferred(
+                || async { Ok::<_, std::io::Error>(vec![1, 2, 3]) },
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency),
+                |result| {
+                    let mut m = HashMap::new();
+                    if let Ok(items) = result {
+                        m.insert("item_count".to_string(), items.len() as f64);
+                    }
+                    m
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 3);
+
+        // Should have 2 samples: latency + item_count
+        let s1 = rx.try_recv().unwrap();
+        let s2 = rx.try_recv().unwrap();
+        let metrics: Vec<&str> = vec![&s1.metric, &s2.metric];
+        assert!(metrics.contains(&"latency"));
+        assert!(metrics.contains(&"item_count"));
+
+        let item_count_sample = if s1.metric == "item_count" { &s1 } else { &s2 };
+        assert_eq!(item_count_sample.value, 3.0);
+        assert!(item_count_sample.ok);
+    }
+
+    #[tokio::test]
+    async fn execute_with_deferred_panic_does_not_crash() {
+        let (client, _rx) = new_test_client();
+
+        let result = client
+            .execute_with_deferred(
+                || async { Ok::<_, std::io::Error>("hello".to_string()) },
+                ExecuteOptions::new().router("r1"),
+                |_result| -> HashMap<String, f64> {
+                    panic!("intentional panic in deferred metrics");
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[tokio::test]
+    async fn execute_with_deferred_on_error() {
+        let (client, mut rx) = new_test_client();
+
+        let result: Result<String, ExecuteError<std::io::Error>> = client
+            .execute_with_deferred(
+                || async { Err::<String, _>(std::io::Error::other("boom")) },
+                ExecuteOptions::new()
+                    .router("r1")
+                    .metric("latency", MetricValue::Latency),
+                |result| {
+                    let mut m = HashMap::new();
+                    if result.is_err() {
+                        m.insert("error_count".to_string(), 1.0);
+                    }
+                    m
+                },
+            )
+            .await;
+        assert!(result.is_err());
+
+        // Should have 2 samples: latency + error_count
+        let s1 = rx.try_recv().unwrap();
+        let s2 = rx.try_recv().unwrap();
+        let metrics: Vec<&str> = vec![&s1.metric, &s2.metric];
+        assert!(metrics.contains(&"latency"));
+        assert!(metrics.contains(&"error_count"));
+    }
+
+    #[tokio::test]
     async fn stats_reflects_counters() {
         let (client, _rx) = new_test_client();
         client
@@ -1276,13 +1459,35 @@ mod tests {
             .store(5, Ordering::Relaxed);
         client
             .inner
+            .ingest
+            .stats
+            .flush_failures
+            .store(2, Ordering::Relaxed);
+        client
+            .inner
+            .ingest
+            .stats
+            .last_successful_flush_ms
+            .store(1700000000000, Ordering::Relaxed);
+        client
+            .inner
             .sse
             .stats
             .connected
             .store(true, Ordering::Relaxed);
+        client
+            .inner
+            .sse
+            .stats
+            .last_event_ms
+            .store(1700000001000, Ordering::Relaxed);
 
         let stats = client.stats();
         assert_eq!(stats.dropped_samples, 5);
+        assert_eq!(stats.flush_failures, 2);
+        assert!(stats.last_successful_flush.is_some());
+        assert!(stats.last_sse_event.is_some());
         assert!(stats.sse_connected);
+        assert_eq!(stats.cached_breakers, 0);
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -120,8 +120,8 @@ async fn flusher_loop(cfg: FlusherConfig) {
                 }
                 if !buffer.is_empty() {
                     let batch = std::mem::take(&mut buffer);
-                    track_flush(&flush_failures, &last_flush_ms,
-                        send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
+                    let ok = send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                    track_flush(&flush_failures, &last_flush_ms, ok);
                 }
                 break;
             }
@@ -149,8 +149,8 @@ async fn flusher_loop(cfg: FlusherConfig) {
             _ = interval.tick() => {
                 if !buffer.is_empty() {
                     let batch = std::mem::take(&mut buffer);
-                    track_flush(&flush_failures, &last_flush_ms,
-                        send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
+                    let ok = send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                    track_flush(&flush_failures, &last_flush_ms, ok);
                 }
             }
         }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,6 +25,8 @@ const BACKOFF_SCHEDULE: &[Duration] = &[
 
 pub(crate) struct IngestStats {
     pub dropped_samples: Arc<AtomicU64>,
+    pub flush_failures: Arc<AtomicU64>,
+    pub last_successful_flush_ms: Arc<AtomicU64>,
 }
 
 pub(crate) struct IngestHandle {
@@ -48,8 +50,12 @@ pub(crate) fn start_flusher(
 ) -> IngestHandle {
     let (tx, rx) = mpsc::channel::<ReportEntry>(CHANNEL_CAPACITY);
     let dropped = Arc::new(AtomicU64::new(0));
+    let flush_failures = Arc::new(AtomicU64::new(0));
+    let last_flush_ms = Arc::new(AtomicU64::new(0));
     let stats = IngestStats {
         dropped_samples: dropped.clone(),
+        flush_failures: flush_failures.clone(),
+        last_successful_flush_ms: last_flush_ms.clone(),
     };
 
     let http = reqwest::Client::builder()
@@ -57,7 +63,7 @@ pub(crate) fn start_flusher(
         .build()
         .expect("failed to build ingest HTTP client");
 
-    let task_handle = tokio::spawn(flusher_loop(
+    let task_handle = tokio::spawn(flusher_loop(FlusherConfig {
         rx,
         http,
         base_url,
@@ -65,7 +71,9 @@ pub(crate) fn start_flusher(
         ingest_secret,
         api_key,
         cancel,
-    ));
+        flush_failures,
+        last_flush_ms,
+    }));
 
     IngestHandle {
         tx,
@@ -74,15 +82,30 @@ pub(crate) fn start_flusher(
     }
 }
 
-async fn flusher_loop(
-    mut rx: mpsc::Receiver<ReportEntry>,
+struct FlusherConfig {
+    rx: mpsc::Receiver<ReportEntry>,
     http: reqwest::Client,
     base_url: String,
     project_id: String,
     ingest_secret: Option<String>,
     api_key: String,
     cancel: CancellationToken,
-) {
+    flush_failures: Arc<AtomicU64>,
+    last_flush_ms: Arc<AtomicU64>,
+}
+
+async fn flusher_loop(cfg: FlusherConfig) {
+    let FlusherConfig {
+        mut rx,
+        http,
+        base_url,
+        project_id,
+        ingest_secret,
+        api_key,
+        cancel,
+        flush_failures,
+        last_flush_ms,
+    } = cfg;
     let url = format!("{base_url}/v1/projects/{project_id}/ingest");
     let mut buffer: Vec<ReportEntry> = Vec::with_capacity(BATCH_SIZE);
     let mut interval = tokio::time::interval(FLUSH_INTERVAL);
@@ -97,7 +120,8 @@ async fn flusher_loop(
                 }
                 if !buffer.is_empty() {
                     let batch = std::mem::take(&mut buffer);
-                    send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                    track_flush(&flush_failures, &last_flush_ms,
+                        send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
                 }
                 break;
             }
@@ -107,14 +131,16 @@ async fn flusher_loop(
                         buffer.push(entry);
                         if buffer.len() >= BATCH_SIZE {
                             let batch = std::mem::take(&mut buffer);
-                            send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                            track_flush(&flush_failures, &last_flush_ms,
+                                send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
                         }
                     }
                     None => {
                         // Channel closed
                         if !buffer.is_empty() {
                             let batch = std::mem::take(&mut buffer);
-                            send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                            track_flush(&flush_failures, &last_flush_ms,
+                                send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
                         }
                         break;
                     }
@@ -123,10 +149,20 @@ async fn flusher_loop(
             _ = interval.tick() => {
                 if !buffer.is_empty() {
                     let batch = std::mem::take(&mut buffer);
-                    send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await;
+                    track_flush(&flush_failures, &last_flush_ms,
+                        send_batch(&http, &url, ingest_secret.as_deref(), &api_key, batch).await);
                 }
             }
         }
+    }
+}
+
+fn track_flush(flush_failures: &AtomicU64, last_flush_ms: &AtomicU64, success: bool) {
+    if success {
+        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+        last_flush_ms.store(now_ms, Ordering::Relaxed);
+    } else {
+        flush_failures.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -136,13 +172,13 @@ async fn send_batch(
     ingest_secret: Option<&str>,
     api_key: &str,
     samples: Vec<ReportEntry>,
-) {
+) -> bool {
     let payload = BatchPayload { samples };
     let json_bytes = match serde_json::to_vec(&payload) {
         Ok(b) => b,
         Err(e) => {
             warn!("failed to serialize ingest payload: {e}");
-            return;
+            return false;
         }
     };
 
@@ -150,13 +186,13 @@ async fn send_batch(
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     if let Err(e) = encoder.write_all(&json_bytes) {
         warn!("failed to gzip ingest payload: {e}");
-        return;
+        return false;
     }
     let compressed = match encoder.finish() {
         Ok(b) => b,
         Err(e) => {
             warn!("failed to finish gzip: {e}");
-            return;
+            return false;
         }
     };
 
@@ -198,11 +234,11 @@ async fn send_batch(
                         "ingest batch sent successfully ({} samples)",
                         payload.samples.len()
                     );
-                    return;
+                    return true;
                 }
                 if status == 401 || status == 403 {
                     warn!("ingest auth error (HTTP {status}), not retrying");
-                    return;
+                    return false;
                 }
                 warn!("ingest request failed (HTTP {status})");
             }
@@ -211,6 +247,7 @@ async fn send_batch(
             }
         }
     }
+    false
 }
 
 pub(crate) fn compute_signature(secret_hex: &str, ts_ms: i64, compressed: &[u8]) -> Option<String> {

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -14,6 +14,7 @@ use crate::types::{BreakerStateEntry, BreakerStateValue};
 pub(crate) struct SseStats {
     pub connected: Arc<AtomicBool>,
     pub reconnects: Arc<AtomicU64>,
+    pub last_event_ms: Arc<AtomicU64>,
 }
 
 pub(crate) struct SseHandle {
@@ -37,10 +38,12 @@ pub(crate) fn start_sse_listener(
         Arc::new(RwLock::new(HashMap::new()));
     let connected = Arc::new(AtomicBool::new(false));
     let reconnects = Arc::new(AtomicU64::new(0));
+    let last_event_ms = Arc::new(AtomicU64::new(0));
 
     let stats = SseStats {
         connected: connected.clone(),
         reconnects: reconnects.clone(),
+        last_event_ms: last_event_ms.clone(),
     };
 
     let states_clone = states.clone();
@@ -53,6 +56,7 @@ pub(crate) fn start_sse_listener(
         states: states_clone,
         connected,
         reconnects,
+        last_event_ms,
         on_state_change,
     }));
 
@@ -72,6 +76,7 @@ struct SseLoopParams {
     states: Arc<RwLock<HashMap<String, BreakerStateEntry>>>,
     connected: Arc<AtomicBool>,
     reconnects: Arc<AtomicU64>,
+    last_event_ms: Arc<AtomicU64>,
     on_state_change: Option<StateChangeCallback>,
 }
 
@@ -85,6 +90,7 @@ async fn sse_loop(p: SseLoopParams) {
         states,
         connected,
         reconnects,
+        last_event_ms,
         on_state_change,
     } = p;
     let url = format!("{base_url}/v1/projects/{project_id}/breakers/state:stream");
@@ -139,6 +145,9 @@ async fn sse_loop(p: SseLoopParams) {
                                 Ok(entry) => {
                                     let name = entry.breaker.clone();
                                     let new_state = entry.state;
+
+                                    let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+                                    last_event_ms.store(now_ms, Ordering::Relaxed);
 
                                     let old_state = {
                                         let mut map = states.write().await;

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,6 +34,10 @@ pub struct SdkStats {
     pub buffer_capacity: usize,
     pub sse_connected: bool,
     pub sse_reconnects: u64,
+    pub flush_failures: u64,
+    pub last_successful_flush: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_sse_event: Option<chrono::DateTime<chrono::Utc>>,
+    pub cached_breakers: usize,
 }
 
 /// Breaker metadata from the metadata cache.


### PR DESCRIPTION
## Summary
- **SdkStats**: Added `flush_failures`, `last_successful_flush`, `last_sse_event`, and `cached_breakers` fields to match Go and Python SDK stats
- **Deferred metrics**: Added `execute_with_deferred()` for computing metrics from task results (equivalent to Go's `WithDeferredMetrics[T]` and Python's `deferred_metrics`)
- **Pagination**: Added `Pager<T>` type with `next()` and `collect_all()` methods, plus `_pager` factory methods on `AdminClient` for all list endpoints

## Test plan
- [x] 151 unit tests pass (5 new: stats, 3 deferred metrics, 2 pager)
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo fmt --check` — clean