### PR TITLE
feat(admin): workspace CRUD + Breaker router_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,13 +455,12 @@ let client = AdminClient::builder("eb_admin_...")
     .build();
 
 // List all projects
-let projects = client.list_projects(None).await?;
+let resp = client.list_projects().await?;
 
 // Create a project
 let project = client
     .create_project(&CreateProjectInput {
         name: "prod-payments".to_string(),
-        description: None,
     })
     .await?;
 
@@ -472,8 +471,7 @@ let project = client.get_project("proj_abc123").await?;
 client.delete_project("proj_abc123", "prod-payments").await?;
 
 // List breakers
-let params = ListParams { page: Some(1), per_page: Some(100) };
-let page = client.list_breakers("proj_abc123", Some(&params)).await?;
+let resp = client.list_breakers("proj_abc123", None).await?;
 
 // Create a breaker
 let breaker = client
@@ -482,15 +480,20 @@ let breaker = client
         &CreateBreakerInput {
             name: "api-latency".to_string(),
             metric: "latency_ms".to_string(),
+            kind: BreakerKind::ErrorRate,
+            kind_params: None,
             threshold: 500.0,
             op: BreakerOp::Gt,
-            window_size: 300,
-            min_samples: 100,
-            kind: None,
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
+            window_ms: Some(300000),
+            min_count: Some(100),
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
             metadata: None,
         },
     )
@@ -516,23 +519,23 @@ let project = client.get_project_with_opts("proj_abc123", Some(&opts)).await?;
 
 ### Pagination
 
-Every list method returns a `Page<T>` with page metadata. For iterating across all pages, use the `_pager` methods:
+Endpoints that support cursor-based pagination have `_pager` methods for automatic iteration:
 
 ```rust
 use tripswitch::admin::pager::Pager;
 
-// Iterate item-by-item across all pages
-let mut pager = client.list_breakers_pager("proj_abc123", None);
-while let Some(breaker) = pager.next().await? {
-    println!("{}: {:?}", breaker.name, breaker.metric);
+// Iterate item-by-item across all pages of events
+let mut pager = client.list_events_pager("proj_abc123", None);
+while let Some(event) = pager.next().await? {
+    println!("{}: {} → {}", event.breaker_id, event.from_state, event.to_state);
 }
 
 // Or collect everything at once
-let mut pager = client.list_routers_pager("proj_abc123", Some(50));
-let all_routers = pager.collect_all().await?;
+let mut pager = client.list_notification_channels_pager("proj_abc123", None);
+let all_channels = pager.collect_all().await?;
 ```
 
-Available pagers: `list_projects_pager`, `list_breakers_pager`, `list_routers_pager`, `list_notification_channels_pager`, `list_events_pager`.
+Available pagers: `list_notification_channels_pager`, `list_events_pager`.
 
 ### Admin Error Handling
 

--- a/src/admin/breakers.rs
+++ b/src/admin/breakers.rs
@@ -1,8 +1,26 @@
 use std::collections::HashMap;
 
+use serde::Deserialize;
+
 use super::errors::AdminError;
 use super::types::*;
 use super::{AdminClient, RequestOptions};
+
+/// Internal envelope returned by single-breaker endpoints.
+#[derive(Deserialize)]
+struct BreakerEnvelope {
+    breaker: Breaker,
+    #[serde(default)]
+    router_ids: Vec<String>,
+}
+
+fn unwrap_breaker_env(env: BreakerEnvelope) -> Breaker {
+    let mut b = env.breaker;
+    if !env.router_ids.is_empty() {
+        b.router_ids = env.router_ids;
+    }
+    b
+}
 
 impl AdminClient {
     pub async fn list_breakers(
@@ -49,7 +67,8 @@ impl AdminClient {
             .http
             .get(self.url(&format!("/v1/projects/{project_id}/breakers/{breaker_id}")))
             .headers(self.auth_headers());
-        self.do_request(builder, opts).await
+        let env: BreakerEnvelope = self.do_request(builder, opts).await?;
+        Ok(unwrap_breaker_env(env))
     }
 
     pub async fn create_breaker(
@@ -71,7 +90,8 @@ impl AdminClient {
             .post(self.url(&format!("/v1/projects/{project_id}/breakers")))
             .headers(self.auth_headers())
             .json(input);
-        self.do_request(builder, opts).await
+        let env: BreakerEnvelope = self.do_request(builder, opts).await?;
+        Ok(unwrap_breaker_env(env))
     }
 
     pub async fn update_breaker(
@@ -96,7 +116,8 @@ impl AdminClient {
             .patch(self.url(&format!("/v1/projects/{project_id}/breakers/{breaker_id}")))
             .headers(self.auth_headers())
             .json(input);
-        self.do_request(builder, opts).await
+        let env: BreakerEnvelope = self.do_request(builder, opts).await?;
+        Ok(unwrap_breaker_env(env))
     }
 
     pub async fn delete_breaker(
@@ -214,6 +235,7 @@ impl AdminClient {
             )))
             .headers(self.auth_headers())
             .json(&serde_json::json!({ "metadata": metadata }));
-        self.do_request(builder, opts).await
+        let env: BreakerEnvelope = self.do_request(builder, opts).await?;
+        Ok(unwrap_breaker_env(env))
     }
 }

--- a/src/admin/breakers.rs
+++ b/src/admin/breakers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::errors::AdminError;
 use super::types::*;
 use super::{AdminClient, RequestOptions};
@@ -192,7 +194,7 @@ impl AdminClient {
         &self,
         project_id: &str,
         breaker_id: &str,
-        metadata: &serde_json::Value,
+        metadata: &HashMap<String, String>,
     ) -> Result<Breaker, AdminError> {
         self.update_breaker_metadata_with_opts(project_id, breaker_id, metadata, None)
             .await
@@ -202,7 +204,7 @@ impl AdminClient {
         &self,
         project_id: &str,
         breaker_id: &str,
-        metadata: &serde_json::Value,
+        metadata: &HashMap<String, String>,
         opts: Option<&RequestOptions>,
     ) -> Result<Breaker, AdminError> {
         let builder = self

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -9,6 +9,7 @@ mod pagers;
 mod project_keys;
 mod projects;
 mod routers;
+mod workspaces;
 
 use errors::{AdminError, ApiError};
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -277,10 +278,9 @@ mod tests {
                 .path("/v1/projects/proj_123")
                 .header("Authorization", "Bearer eb_admin_test");
             then.status(200).json_body(json!({
-                "id": "proj_123",
+                "project_id": "proj_123",
                 "name": "My Project",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "enable_signed_ingest": false
             }));
         });
 
@@ -298,20 +298,18 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(GET).path("/v1/projects");
             then.status(200).json_body(json!({
-                "data": [
-                    {"id":"p1","name":"Proj 1","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},
-                    {"id":"p2","name":"Proj 2","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}
-                ],
-                "page": 1, "per_page": 10, "total": 2, "total_pages": 1
+                "projects": [
+                    {"project_id":"p1","name":"Proj 1","enable_signed_ingest":false},
+                    {"project_id":"p2","name":"Proj 2","enable_signed_ingest":false}
+                ]
             }));
         });
 
         let client = test_client(&server);
-        let resp = client.list_projects(None).await.unwrap();
+        let resp = client.list_projects().await.unwrap();
 
         mock.assert();
-        assert_eq!(resp.data.len(), 2);
-        assert_eq!(resp.total, 2);
+        assert_eq!(resp.projects.len(), 2);
     }
 
     #[tokio::test]
@@ -322,17 +320,15 @@ mod tests {
                 .path("/v1/projects")
                 .json_body(json!({"name": "my-project"}));
             then.status(201).json_body(json!({
-                "id": "proj_new",
+                "project_id": "proj_new",
                 "name": "my-project",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "enable_signed_ingest": false
             }));
         });
 
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "my-project".to_string(),
-            description: None,
         };
         let project = client.create_project(&input).await.unwrap();
 
@@ -348,17 +344,18 @@ mod tests {
                 .path("/v1/projects/proj_123")
                 .json_body(json!({"name": "Updated Name"}));
             then.status(200).json_body(json!({
-                "id": "proj_123",
+                "project_id": "proj_123",
                 "name": "Updated Name",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "enable_signed_ingest": false
             }));
         });
 
         let client = test_client(&server);
         let input = UpdateProjectInput {
             name: Some("Updated Name".to_string()),
-            description: None,
+            slack_webhook_url: None,
+            trace_id_url_template: None,
+            enable_signed_ingest: None,
         };
         let project = client.update_project("proj_123", &input).await.unwrap();
 
@@ -394,16 +391,13 @@ mod tests {
                 .header("Authorization", "Bearer eb_admin_test");
             then.status(201).json_body(json!({
                 "id": "breaker_456",
-                "project_id": "proj_123",
                 "name": "api-latency",
-                "kind": "standard",
+                "kind": "error_rate",
                 "metric": "p99_latency",
                 "threshold": 500.0,
                 "op": "gt",
-                "window_size": 300,
-                "min_samples": 100,
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "window_ms": 300000,
+                "min_count": 100
             }));
         });
 
@@ -411,15 +405,20 @@ mod tests {
         let input = CreateBreakerInput {
             name: "api-latency".to_string(),
             metric: "p99_latency".to_string(),
+            kind: BreakerKind::ErrorRate,
+            kind_params: None,
             threshold: 500.0,
             op: BreakerOp::Gt,
-            window_size: 300,
-            min_samples: 100,
-            kind: None,
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
+            window_ms: Some(300000),
+            min_count: Some(100),
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
             metadata: None,
         };
         let breaker = client.create_breaker("proj_123", &input).await.unwrap();
@@ -430,38 +429,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_breakers_with_query_params() {
+    async fn list_breakers_returns_response() {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/projects/proj_123/breakers")
-                .query_param("page", "1")
-                .query_param("per_page", "10");
+            when.method(GET).path("/v1/projects/proj_123/breakers");
             then.status(200).json_body(json!({
-                "data": [
+                "breakers": [
                     {
-                        "id": "b1", "project_id": "proj_123", "name": "breaker-1",
-                        "kind": "standard", "metric": "latency", "threshold": 100.0,
-                        "op": "gt", "window_size": 60, "min_samples": 10,
-                        "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"
+                        "id": "b1", "name": "breaker-1",
+                        "kind": "error_rate", "metric": "latency", "threshold": 100.0,
+                        "op": "gt"
                     }
                 ],
-                "page": 1, "per_page": 10, "total": 1, "total_pages": 1
+                "count": 1
             }));
         });
 
         let client = test_client(&server);
-        let params = ListParams {
-            page: Some(1),
-            per_page: Some(10),
-        };
-        let resp = client
-            .list_breakers("proj_123", Some(&params))
-            .await
-            .unwrap();
+        let resp = client.list_breakers("proj_123", None).await.unwrap();
 
         mock.assert();
-        assert_eq!(resp.data.len(), 1);
+        assert_eq!(resp.breakers.len(), 1);
+        assert_eq!(resp.count, 1);
     }
 
     #[tokio::test]
@@ -488,30 +477,28 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/projects/proj_123/routers")
-                .json_body(json!({"name": "my-router", "mode": "round_robin"}));
+                .json_body(json!({"name": "my-router", "mode": "static"}));
             then.status(201).json_body(json!({
                 "id": "router_789",
-                "project_id": "proj_123",
                 "name": "my-router",
-                "mode": "round_robin",
-                "breaker_ids": [],
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "mode": "static",
+                "enabled": true
             }));
         });
 
         let client = test_client(&server);
         let input = CreateRouterInput {
             name: "my-router".to_string(),
+            mode: RouterMode::Static,
             description: None,
-            mode: Some(RouterMode::RoundRobin),
+            enabled: None,
             metadata: None,
         };
         let router = client.create_router("proj_123", &input).await.unwrap();
 
         mock.assert();
         assert_eq!(router.id, "router_789");
-        assert_eq!(router.mode, RouterMode::RoundRobin);
+        assert_eq!(router.mode, RouterMode::Static);
     }
 
     #[tokio::test]
@@ -546,9 +533,8 @@ mod tests {
                 "id": "nc_1",
                 "project_id": "proj_123",
                 "name": "slack-alerts",
-                "channel_type": "slack",
-                "events": ["breaker_opened", "breaker_closed"],
-                "breaker_ids": [],
+                "channel": "slack",
+                "events": ["trip", "recover"],
                 "enabled": true,
                 "created_at": "2024-01-01T00:00:00Z",
                 "updated_at": "2024-01-01T00:00:00Z"
@@ -558,13 +544,12 @@ mod tests {
         let client = test_client(&server);
         let input = CreateNotificationChannelInput {
             name: "slack-alerts".to_string(),
-            channel_type: NotificationChannelType::Slack,
+            channel: NotificationChannelType::Slack,
             config: None,
             events: Some(vec![
-                NotificationEventType::BreakerOpened,
-                NotificationEventType::BreakerClosed,
+                NotificationEventType::Trip,
+                NotificationEventType::Recover,
             ]),
-            breaker_ids: None,
             enabled: None,
         };
         let channel = client
@@ -573,7 +558,7 @@ mod tests {
             .unwrap();
 
         mock.assert();
-        assert_eq!(channel.channel_type, NotificationChannelType::Slack);
+        assert_eq!(channel.channel, NotificationChannelType::Slack);
         assert_eq!(channel.events.len(), 2);
     }
 
@@ -585,21 +570,23 @@ mod tests {
                 .path("/v1/projects/proj_123/events")
                 .query_param("breaker_id", "b_456");
             then.status(200).json_body(json!({
-                "data": [
+                "events": [
                     {
                         "id": "ev_1", "project_id": "proj_123",
-                        "event_type": "breaker_opened",
                         "breaker_id": "b_456",
-                        "created_at": "2024-01-01T00:00:00Z"
+                        "from_state": "closed",
+                        "to_state": "open",
+                        "timestamp": "2024-01-01T00:00:00Z"
                     },
                     {
                         "id": "ev_2", "project_id": "proj_123",
-                        "event_type": "breaker_closed",
                         "breaker_id": "b_456",
-                        "created_at": "2024-01-02T00:00:00Z"
+                        "from_state": "open",
+                        "to_state": "closed",
+                        "timestamp": "2024-01-02T00:00:00Z"
                     }
                 ],
-                "page": 1, "per_page": 10, "total": 2, "total_pages": 1
+                "returned": 2
             }));
         });
 
@@ -611,7 +598,8 @@ mod tests {
         let resp = client.list_events("proj_123", Some(&params)).await.unwrap();
 
         mock.assert();
-        assert_eq!(resp.data.len(), 2);
+        assert_eq!(resp.events.len(), 2);
+        assert_eq!(resp.returned, 2);
     }
 
     // ── Error Classification with Mock Servers ─────────────────────
@@ -690,7 +678,6 @@ mod tests {
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "dup".to_string(),
-            description: None,
         };
         let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_conflict());
@@ -710,7 +697,6 @@ mod tests {
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "".to_string(),
-            description: None,
         };
         let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_validation());
@@ -752,9 +738,8 @@ mod tests {
                 .header("Idempotency-Key", "idem_456")
                 .header("X-Request-ID", "trace_123");
             then.status(200).json_body(json!({
-                "id": "proj_123", "name": "Test",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "project_id": "proj_123", "name": "Test",
+                "enable_signed_ingest": false
             }));
         });
 
@@ -781,9 +766,8 @@ mod tests {
                 .path("/v1/projects/proj_123")
                 .header("X-Custom", "value");
             then.status(200).json_body(json!({
-                "id": "proj_123", "name": "Test",
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "project_id": "proj_123", "name": "Test",
+                "enable_signed_ingest": false
             }));
         });
 
@@ -810,9 +794,8 @@ mod tests {
             then.status(200)
                 .delay(std::time::Duration::from_millis(200))
                 .json_body(json!({
-                    "id": "proj_123", "name": "Test",
-                    "created_at": "2024-01-01T00:00:00Z",
-                    "updated_at": "2024-01-01T00:00:00Z"
+                    "project_id": "proj_123", "name": "Test",
+                    "enable_signed_ingest": false
                 }));
         });
 
@@ -836,12 +819,10 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST).path("/v1/projects/proj_123/breakers");
             then.status(201).json_body(json!({
-                "id": "b1", "project_id": "proj_123", "name": "test",
-                "kind": "standard", "metric": "latency", "threshold": 100.0,
-                "op": "gt", "window_size": 60, "min_samples": 10,
-                "metadata": {"region": "us-east-1"},
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "id": "b1", "name": "test",
+                "kind": "error_rate", "metric": "latency", "threshold": 100.0,
+                "op": "gt",
+                "metadata": {"region": "us-east-1"}
             }));
         });
 
@@ -849,16 +830,24 @@ mod tests {
         let input = CreateBreakerInput {
             name: "test".to_string(),
             metric: "latency".to_string(),
+            kind: BreakerKind::ErrorRate,
+            kind_params: None,
             threshold: 100.0,
             op: BreakerOp::Gt,
-            window_size: 60,
-            min_samples: 10,
-            kind: None,
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
-            metadata: Some(serde_json::json!({"region": "us-east-1"})),
+            window_ms: Some(60000),
+            min_count: Some(10),
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
+            metadata: Some(std::collections::HashMap::from([(
+                "region".to_string(),
+                "us-east-1".to_string(),
+            )])),
         };
         let breaker = client.create_breaker("proj_123", &input).await.unwrap();
 
@@ -872,11 +861,9 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST).path("/v1/projects/proj_123/breakers");
             then.status(201).json_body(json!({
-                "id": "b2", "project_id": "proj_123", "name": "no-meta",
-                "kind": "standard", "metric": "latency", "threshold": 100.0,
-                "op": "gt", "window_size": 60, "min_samples": 10,
-                "created_at": "2024-01-01T00:00:00Z",
-                "updated_at": "2024-01-01T00:00:00Z"
+                "id": "b2", "name": "no-meta",
+                "kind": "error_rate", "metric": "latency", "threshold": 100.0,
+                "op": "gt"
             }));
         });
 
@@ -884,15 +871,20 @@ mod tests {
         let input = CreateBreakerInput {
             name: "no-meta".to_string(),
             metric: "latency".to_string(),
+            kind: BreakerKind::ErrorRate,
+            kind_params: None,
             threshold: 100.0,
             op: BreakerOp::Gt,
-            window_size: 60,
-            min_samples: 10,
-            kind: None,
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
+            window_ms: Some(60000),
+            min_count: Some(10),
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
             metadata: None,
         };
         let breaker = client.create_breaker("proj_123", &input).await.unwrap();
@@ -906,55 +898,52 @@ mod tests {
     #[tokio::test]
     async fn pager_iterates_across_pages() {
         let server = MockServer::start();
+        // Register the specific cursor mock first so it matches before the general one
         server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/projects")
-                .query_param("page", "1")
-                .query_param("per_page", "2");
+                .path("/v1/projects/proj_123/events")
+                .query_param("cursor", "cursor_page2");
             then.status(200).json_body(json!({
-                "data": [
-                    {"id":"p1","name":"P1","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},
-                    {"id":"p2","name":"P2","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}
+                "events": [
+                    {"id":"e3","project_id":"proj_123","breaker_id":"b1","from_state":"closed","to_state":"open","timestamp":"2024-01-03T00:00:00Z"}
                 ],
-                "page": 1, "per_page": 2, "total": 3, "total_pages": 2
+                "returned": 1
             }));
         });
         server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/projects")
-                .query_param("page", "2")
-                .query_param("per_page", "2");
+                .path("/v1/projects/proj_123/events");
             then.status(200).json_body(json!({
-                "data": [
-                    {"id":"p3","name":"P3","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}
+                "events": [
+                    {"id":"e1","project_id":"proj_123","breaker_id":"b1","from_state":"closed","to_state":"open","timestamp":"2024-01-01T00:00:00Z"},
+                    {"id":"e2","project_id":"proj_123","breaker_id":"b1","from_state":"open","to_state":"closed","timestamp":"2024-01-02T00:00:00Z"}
                 ],
-                "page": 2, "per_page": 2, "total": 3, "total_pages": 2
+                "returned": 2,
+                "next_cursor": "cursor_page2"
             }));
         });
 
         let client = test_client(&server);
-        let mut pager = client.list_projects_pager(Some(2));
+        let mut pager = client.list_events_pager("proj_123", None);
         let all = pager.collect_all().await.unwrap();
         assert_eq!(all.len(), 3);
-        assert_eq!(all[0].id, "p1");
-        assert_eq!(all[2].id, "p3");
+        assert_eq!(all[0].id, "e1");
+        assert_eq!(all[2].id, "e3");
     }
 
     #[tokio::test]
     async fn pager_empty_result() {
         let server = MockServer::start();
         server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/projects/proj_123/breakers")
-                .query_param("page", "1");
+            when.method(GET).path("/v1/projects/proj_123/events");
             then.status(200).json_body(json!({
-                "data": [],
-                "page": 1, "per_page": 100, "total": 0, "total_pages": 0
+                "events": [],
+                "returned": 0
             }));
         });
 
         let client = test_client(&server);
-        let mut pager = client.list_breakers_pager("proj_123", None);
+        let mut pager = client.list_events_pager("proj_123", None);
         let result = pager.next().await.unwrap();
         assert!(result.is_none());
     }

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -289,7 +289,7 @@ mod tests {
 
         mock.assert();
         assert_eq!(project.id, "proj_123");
-        assert_eq!(project.name, "My Project");
+        assert_eq!(project.name.as_deref(), Some("My Project"));
     }
 
     #[tokio::test]
@@ -329,11 +329,12 @@ mod tests {
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "my-project".to_string(),
+            workspace_id: None,
         };
         let project = client.create_project(&input).await.unwrap();
 
         mock.assert();
-        assert_eq!(project.name, "my-project");
+        assert_eq!(project.name.as_deref(), Some("my-project"));
     }
 
     #[tokio::test]
@@ -360,7 +361,7 @@ mod tests {
         let project = client.update_project("proj_123", &input).await.unwrap();
 
         mock.assert();
-        assert_eq!(project.name, "Updated Name");
+        assert_eq!(project.name.as_deref(), Some("Updated Name"));
     }
 
     #[tokio::test]
@@ -390,14 +391,16 @@ mod tests {
                 .path("/v1/projects/proj_123/breakers")
                 .header("Authorization", "Bearer eb_admin_test");
             then.status(201).json_body(json!({
-                "id": "breaker_456",
-                "name": "api-latency",
-                "kind": "error_rate",
-                "metric": "p99_latency",
-                "threshold": 500.0,
-                "op": "gt",
-                "window_ms": 300000,
-                "min_count": 100
+                "breaker": {
+                    "id": "breaker_456",
+                    "name": "api-latency",
+                    "kind": "error_rate",
+                    "metric": "p99_latency",
+                    "threshold": 500.0,
+                    "op": "gt",
+                    "window_ms": 300000,
+                    "min_count": 100
+                }
             }));
         });
 
@@ -678,6 +681,7 @@ mod tests {
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "dup".to_string(),
+            workspace_id: None,
         };
         let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_conflict());
@@ -697,6 +701,7 @@ mod tests {
         let client = test_client(&server);
         let input = CreateProjectInput {
             name: "".to_string(),
+            workspace_id: None,
         };
         let err = client.create_project(&input).await.unwrap_err();
         assert!(err.is_validation());
@@ -819,10 +824,12 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST).path("/v1/projects/proj_123/breakers");
             then.status(201).json_body(json!({
-                "id": "b1", "name": "test",
-                "kind": "error_rate", "metric": "latency", "threshold": 100.0,
-                "op": "gt",
-                "metadata": {"region": "us-east-1"}
+                "breaker": {
+                    "id": "b1", "name": "test",
+                    "kind": "error_rate", "metric": "latency", "threshold": 100.0,
+                    "op": "gt",
+                    "metadata": {"region": "us-east-1"}
+                }
             }));
         });
 
@@ -861,9 +868,11 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST).path("/v1/projects/proj_123/breakers");
             then.status(201).json_body(json!({
-                "id": "b2", "name": "no-meta",
-                "kind": "error_rate", "metric": "latency", "threshold": 100.0,
-                "op": "gt"
+                "breaker": {
+                    "id": "b2", "name": "no-meta",
+                    "kind": "error_rate", "metric": "latency", "threshold": 100.0,
+                    "op": "gt"
+                }
             }));
         });
 

--- a/src/admin/pager.rs
+++ b/src/admin/pager.rs
@@ -3,24 +3,34 @@ use std::future::Future;
 use std::pin::Pin;
 
 use super::errors::AdminError;
-use super::types::Page;
+
+/// Result of fetching a page: items + optional next cursor.
+pub struct CursorPage<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+}
 
 type FetchFn<T> = Box<
-    dyn Fn(i64) -> Pin<Box<dyn Future<Output = Result<Page<T>, AdminError>> + Send>> + Send + Sync,
+    dyn Fn(
+            Option<String>,
+        ) -> Pin<Box<dyn Future<Output = Result<CursorPage<T>, AdminError>> + Send>>
+        + Send
+        + Sync,
 >;
 
-/// An async page iterator for admin list endpoints.
+/// An async cursor-based page iterator for admin list endpoints.
 ///
 /// ```ignore
-/// let mut pager = client.list_breakers_pager("proj_123", None);
-/// while let Some(breaker) = pager.next().await? {
-///     println!("{}", breaker.name);
+/// let mut pager = client.list_events_pager("proj_123", None);
+/// while let Some(event) = pager.next().await? {
+///     println!("{}", event.id);
 /// }
 /// ```
 pub struct Pager<T> {
     fetch: FetchFn<T>,
-    current_page: i64,
+    next_cursor: Option<String>,
     buffer: VecDeque<T>,
+    started: bool,
     done: bool,
 }
 
@@ -28,8 +38,9 @@ impl<T: Send + 'static> Pager<T> {
     pub(crate) fn new(fetch: FetchFn<T>) -> Self {
         Self {
             fetch,
-            current_page: 1,
+            next_cursor: None,
             buffer: VecDeque::new(),
+            started: false,
             done: false,
         }
     }
@@ -46,13 +57,30 @@ impl<T: Send + 'static> Pager<T> {
                 return Ok(None);
             }
 
-            let page = (self.fetch)(self.current_page).await?;
-            self.buffer = page.data.into();
+            let cursor = if self.started {
+                self.next_cursor.take()
+            } else {
+                self.started = true;
+                None
+            };
 
-            if self.current_page >= page.total_pages || self.buffer.is_empty() {
+            // If we've already started and there's no next cursor, we're done
+            if self.started && cursor.is_none() && !self.buffer.is_empty() {
+                self.done = true;
+                continue;
+            }
+
+            let page = (self.fetch)(cursor).await?;
+            self.buffer = page.items.into();
+
+            match page.next_cursor {
+                Some(c) if !c.is_empty() => self.next_cursor = Some(c),
+                _ => self.done = true,
+            }
+
+            if self.buffer.is_empty() {
                 self.done = true;
             }
-            self.current_page += 1;
         }
     }
 

--- a/src/admin/pager.rs
+++ b/src/admin/pager.rs
@@ -64,12 +64,6 @@ impl<T: Send + 'static> Pager<T> {
                 None
             };
 
-            // If we've already started and there's no next cursor, we're done
-            if self.started && cursor.is_none() && !self.buffer.is_empty() {
-                self.done = true;
-                continue;
-            }
-
             let page = (self.fetch)(cursor).await?;
             self.buffer = page.items.into();
 

--- a/src/admin/pagers.rs
+++ b/src/admin/pagers.rs
@@ -21,7 +21,7 @@ impl AdminClient {
                     .list_notification_channels(&pid, Some(&params))
                     .await?;
                 Ok(CursorPage {
-                    items: resp.items,
+                    items: resp.channels,
                     next_cursor: resp.next_cursor,
                 })
             })

--- a/src/admin/pagers.rs
+++ b/src/admin/pagers.rs
@@ -1,70 +1,53 @@
-use super::pager::Pager;
+use super::pager::{CursorPage, Pager};
 use super::types::*;
 use super::AdminClient;
 
-macro_rules! project_pager {
-    ($method:ident, $list:ident, $T:ty) => {
-        pub fn $method(&self, project_id: impl Into<String>, per_page: Option<i64>) -> Pager<$T> {
-            let client = self.clone();
-            let pid = project_id.into();
-            let pp = per_page.unwrap_or(100);
-            Pager::new(Box::new(move |page| {
-                let client = client.clone();
-                let pid = pid.clone();
-                Box::pin(async move {
-                    let params = ListParams {
-                        page: Some(page),
-                        per_page: Some(pp),
-                    };
-                    client.$list(&pid, Some(&params)).await
-                })
-            }))
-        }
-    };
-}
-
 impl AdminClient {
-    /// Create a pager that iterates over all projects.
-    pub fn list_projects_pager(&self, per_page: Option<i64>) -> Pager<Project> {
+    /// Create a pager that iterates over all notification channels in a project.
+    pub fn list_notification_channels_pager(
+        &self,
+        project_id: impl Into<String>,
+        limit: Option<i64>,
+    ) -> Pager<NotificationChannel> {
         let client = self.clone();
-        let pp = per_page.unwrap_or(100);
-        Pager::new(Box::new(move |page| {
+        let pid = project_id.into();
+        Pager::new(Box::new(move |cursor| {
             let client = client.clone();
+            let pid = pid.clone();
+            let limit = limit;
             Box::pin(async move {
-                let params = ListParams {
-                    page: Some(page),
-                    per_page: Some(pp),
-                };
-                client.list_projects(Some(&params)).await
+                let params = ListParams { cursor, limit };
+                let resp = client
+                    .list_notification_channels(&pid, Some(&params))
+                    .await?;
+                Ok(CursorPage {
+                    items: resp.items,
+                    next_cursor: resp.next_cursor,
+                })
             })
         }))
     }
-
-    project_pager!(list_breakers_pager, list_breakers, Breaker);
-    project_pager!(list_routers_pager, list_routers, Router);
-    project_pager!(
-        list_notification_channels_pager,
-        list_notification_channels,
-        NotificationChannel
-    );
 
     /// Create a pager that iterates over all events in a project.
     pub fn list_events_pager(
         &self,
         project_id: impl Into<String>,
         params: Option<ListEventsParams>,
-        per_page: Option<i64>,
     ) -> Pager<Event> {
         let client = self.clone();
         let pid = project_id.into();
-        let pp = per_page.unwrap_or(100);
-        Pager::new(Box::new(move |page| {
+        Pager::new(Box::new(move |cursor| {
             let client = client.clone();
             let pid = pid.clone();
             let mut p = params.clone().unwrap_or_default();
-            p.page = Some(page);
-            p.per_page = Some(pp);
-            Box::pin(async move { client.list_events(&pid, Some(&p)).await })
+            p.cursor = cursor;
+            Box::pin(async move {
+                let resp = client.list_events(&pid, Some(&p)).await?;
+                Ok(CursorPage {
+                    items: resp.events,
+                    next_cursor: resp.next_cursor,
+                })
+            })
         }))
     }
 }

--- a/src/admin/projects.rs
+++ b/src/admin/projects.rs
@@ -3,26 +3,18 @@ use super::types::*;
 use super::{AdminClient, RequestOptions};
 
 impl AdminClient {
-    pub async fn list_projects(
-        &self,
-        params: Option<&ListParams>,
-    ) -> Result<ListProjectsResponse, AdminError> {
-        self.list_projects_with_opts(params, None).await
+    pub async fn list_projects(&self) -> Result<ListProjectsResponse, AdminError> {
+        self.list_projects_with_opts(None).await
     }
 
     pub async fn list_projects_with_opts(
         &self,
-        params: Option<&ListParams>,
         opts: Option<&RequestOptions>,
     ) -> Result<ListProjectsResponse, AdminError> {
-        let url = self.url("/v1/projects");
-        let mut builder = self.http.get(&url).headers(self.auth_headers());
-        if let Some(p) = params {
-            let pairs = p.to_query_pairs();
-            if !pairs.is_empty() {
-                builder = builder.query(&pairs);
-            }
-        }
+        let builder = self
+            .http
+            .get(self.url("/v1/projects"))
+            .headers(self.auth_headers());
         self.do_request(builder, opts).await
     }
 

--- a/src/admin/routers.rs
+++ b/src/admin/routers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::errors::AdminError;
 use super::types::*;
 use super::{AdminClient, RequestOptions};
@@ -171,7 +173,7 @@ impl AdminClient {
         &self,
         project_id: &str,
         router_id: &str,
-        metadata: &serde_json::Value,
+        metadata: &HashMap<String, String>,
     ) -> Result<Router, AdminError> {
         self.update_router_metadata_with_opts(project_id, router_id, metadata, None)
             .await
@@ -181,7 +183,7 @@ impl AdminClient {
         &self,
         project_id: &str,
         router_id: &str,
-        metadata: &serde_json::Value,
+        metadata: &HashMap<String, String>,
         opts: Option<&RequestOptions>,
     ) -> Result<Router, AdminError> {
         let builder = self

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -1,13 +1,23 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // ── Enums ──────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BreakerKind {
-    Standard,
-    Canary,
+    ErrorRate,
+    Avg,
+    P95,
+    Max,
+    Min,
+    Sum,
+    Stddev,
+    Count,
+    Percentile,
+    ConsecutiveFailures,
+    Delta,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,158 +27,177 @@ pub enum BreakerOp {
     Gte,
     Lt,
     Lte,
-    Eq,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HalfOpenPolicy {
-    Probabilistic,
-    Disabled,
+    Optimistic,
+    Conservative,
+    Pessimistic,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RouterMode {
-    Random,
-    RoundRobin,
-    Hash,
+    Static,
+    Canary,
+    Weighted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationChannelType {
     Slack,
+    #[serde(rename = "pagerduty")]
+    PagerDuty,
     Email,
     Webhook,
-    PagerDuty,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationEventType {
-    BreakerOpened,
-    BreakerClosed,
-    BreakerHalfOpened,
-    BreakerCreated,
-    BreakerDeleted,
+    Trip,
+    Recover,
 }
-
-pub use crate::types::BreakerStateValue;
 
 // ── Domain Structs ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
+    #[serde(rename = "project_id")]
     pub id: String,
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    pub slack_webhook_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id_url_template: Option<String>,
+    #[serde(default)]
+    pub enable_signed_ingest: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Breaker {
     pub id: String,
-    pub project_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub router_ids: Vec<String>,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    pub kind: BreakerKind,
     pub metric: String,
-    pub threshold: f64,
+    pub kind: BreakerKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind_params: Option<HashMap<String, serde_json::Value>>,
     pub op: BreakerOp,
-    pub window_size: i64,
-    pub min_samples: i64,
+    pub threshold: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_policy: Option<HalfOpenPolicy>,
+    pub window_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_max_rate: Option<f64>,
+    pub min_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cooldown: Option<i64>,
+    pub min_state_duration_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    pub cooldown_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_interval_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_confirmation_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_backoff_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_backoff_cap_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_indeterminate_policy: Option<HalfOpenPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_window_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_allow_rate_ramp_steps: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BreakerState {
     pub breaker_id: String,
-    pub breaker_name: String,
-    pub state: BreakerStateValue,
+    pub state: String,
+    pub allow_rate: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allow_rate: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_evaluated_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Router {
     pub id: String,
-    pub project_id: String,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
     pub mode: RouterMode,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
     #[serde(default)]
-    pub breaker_ids: Vec<String>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breaker_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breakers: Option<Vec<Breaker>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inserted_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationChannel {
     pub id: String,
-    pub project_id: String,
-    pub name: String,
-    pub channel_type: NotificationChannelType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub config: Option<serde_json::Value>,
+    pub project_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub channel: NotificationChannelType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     pub events: Vec<NotificationEventType>,
     #[serde(default)]
-    pub breaker_ids: Vec<String>,
     pub enabled: bool,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
     pub id: String,
     pub project_id: String,
-    pub event_type: String,
+    pub breaker_id: String,
+    pub from_state: String,
+    pub to_state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub breaker_id: Option<String>,
+    pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub breaker_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<serde_json::Value>,
-    pub created_at: DateTime<Utc>,
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectKey {
     pub id: String,
-    pub project_id: String,
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prefix: Option<String>,
+    pub key_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scopes: Option<Vec<String>>,
-    pub created_at: DateTime<Utc>,
+    pub last_used_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<DateTime<Utc>>,
+    pub inserted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectKeyResponse {
-    pub key: ProjectKey,
-    pub raw_key: String,
+    pub id: String,
+    pub name: String,
+    pub key: String,
+    pub key_prefix: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -181,8 +210,6 @@ pub struct IngestSecretRotation {
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateProjectInput {
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -190,29 +217,44 @@ pub struct UpdateProjectInput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub slack_webhook_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id_url_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_signed_ingest: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateBreakerInput {
     pub name: String,
     pub metric: String,
-    pub threshold: f64,
+    pub kind: BreakerKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind_params: Option<HashMap<String, serde_json::Value>>,
     pub op: BreakerOp,
-    pub window_size: i64,
-    pub min_samples: i64,
+    pub threshold: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub kind: Option<BreakerKind>,
+    pub window_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub min_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_policy: Option<HalfOpenPolicy>,
+    pub min_state_duration_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_max_rate: Option<f64>,
+    pub cooldown_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cooldown: Option<i64>,
+    pub eval_interval_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
+    pub half_open_backoff_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_backoff_cap_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_indeterminate_policy: Option<HalfOpenPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_allow_rate_ramp_steps: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -220,36 +262,49 @@ pub struct UpdateBreakerInput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metric: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub threshold: Option<f64>,
+    pub kind: Option<BreakerKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind_params: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op: Option<BreakerOp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub window_size: Option<i64>,
+    pub threshold: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_samples: Option<i64>,
+    pub window_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_policy: Option<HalfOpenPolicy>,
+    pub min_count: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub half_open_max_rate: Option<f64>,
+    pub min_state_duration_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cooldown: Option<i64>,
+    pub cooldown_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
+    pub eval_interval_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_backoff_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_backoff_cap_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub half_open_indeterminate_policy: Option<HalfOpenPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_allow_rate_ramp_steps: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateRouterInput {
     pub name: String,
+    pub mode: RouterMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<RouterMode>,
+    pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -261,19 +316,19 @@ pub struct UpdateRouterInput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<RouterMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<serde_json::Value>,
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateNotificationChannelInput {
     pub name: String,
-    pub channel_type: NotificationChannelType,
+    pub channel: NotificationChannelType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub config: Option<serde_json::Value>,
+    pub config: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<Vec<NotificationEventType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub breaker_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 }
@@ -283,32 +338,17 @@ pub struct UpdateNotificationChannelInput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub config: Option<serde_json::Value>,
+    pub config: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<Vec<NotificationEventType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub breaker_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateProjectKeyInput {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scopes: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct UpdateProjectKeyInput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scopes: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<DateTime<Utc>>,
 }
 
 // ── Helper / Special Structs ───────────────────────────────────────
@@ -320,7 +360,10 @@ pub struct SyncBreakersInput {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchGetBreakerStatesInput {
-    pub breaker_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breaker_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub router_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -328,22 +371,95 @@ pub struct LinkBreakerInput {
     pub breaker_id: String,
 }
 
+// ── Workspaces ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workspace {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub org_id: String,
+    pub inserted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateWorkspaceInput {
+    pub name: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateWorkspaceInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListWorkspacesResponse {
+    pub workspaces: Vec<Workspace>,
+}
+
+// ── Response Wrappers ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListProjectsResponse {
+    pub projects: Vec<Project>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListBreakersResponse {
+    pub breakers: Vec<Breaker>,
+    pub count: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListRoutersResponse {
+    pub routers: Vec<Router>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListEventsResponse {
+    pub events: Vec<Event>,
+    pub returned: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListNotificationChannelsResponse {
+    pub items: Vec<NotificationChannel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListProjectKeysResponse {
+    pub keys: Vec<ProjectKey>,
+    pub count: i64,
+}
+
 // ── Pagination ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
 pub struct ListParams {
-    pub page: Option<i64>,
-    pub per_page: Option<i64>,
+    pub cursor: Option<String>,
+    pub limit: Option<i64>,
 }
 
 impl ListParams {
     pub fn to_query_pairs(&self) -> Vec<(&str, String)> {
         let mut pairs = Vec::new();
-        if let Some(page) = self.page {
-            pairs.push(("page", page.to_string()));
+        if let Some(ref cursor) = self.cursor {
+            pairs.push(("cursor", cursor.clone()));
         }
-        if let Some(per_page) = self.per_page {
-            pairs.push(("per_page", per_page.to_string()));
+        if let Some(limit) = self.limit {
+            pairs.push(("limit", limit.to_string()));
         }
         pairs
     }
@@ -351,46 +467,34 @@ impl ListParams {
 
 #[derive(Debug, Clone, Default)]
 pub struct ListEventsParams {
-    pub page: Option<i64>,
-    pub per_page: Option<i64>,
     pub breaker_id: Option<String>,
-    pub event_type: Option<String>,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub cursor: Option<String>,
+    pub limit: Option<i64>,
 }
 
 impl ListEventsParams {
     pub fn to_query_pairs(&self) -> Vec<(&str, String)> {
         let mut pairs = Vec::new();
-        if let Some(page) = self.page {
-            pairs.push(("page", page.to_string()));
-        }
-        if let Some(per_page) = self.per_page {
-            pairs.push(("per_page", per_page.to_string()));
-        }
         if let Some(ref breaker_id) = self.breaker_id {
             pairs.push(("breaker_id", breaker_id.clone()));
         }
-        if let Some(ref event_type) = self.event_type {
-            pairs.push(("event_type", event_type.clone()));
+        if let Some(ref start_time) = self.start_time {
+            pairs.push(("start_time", start_time.to_rfc3339()));
+        }
+        if let Some(ref end_time) = self.end_time {
+            pairs.push(("end_time", end_time.to_rfc3339()));
+        }
+        if let Some(ref cursor) = self.cursor {
+            pairs.push(("cursor", cursor.clone()));
+        }
+        if let Some(limit) = self.limit {
+            pairs.push(("limit", limit.to_string()));
         }
         pairs
     }
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Page<T> {
-    pub data: Vec<T>,
-    pub page: i64,
-    pub per_page: i64,
-    pub total: i64,
-    pub total_pages: i64,
-}
-
-pub type ListProjectsResponse = Page<Project>;
-pub type ListBreakersResponse = Page<Breaker>;
-pub type ListRoutersResponse = Page<Router>;
-pub type ListNotificationChannelsResponse = Page<NotificationChannel>;
-pub type ListEventsResponse = Page<Event>;
-pub type ListProjectKeysResponse = Page<ProjectKey>;
 
 #[cfg(test)]
 mod tests {
@@ -400,18 +504,24 @@ mod tests {
 
     #[test]
     fn breaker_kind_serde() {
-        assert_eq!(
-            serde_json::to_string(&BreakerKind::Standard).unwrap(),
-            r#""standard""#
-        );
-        assert_eq!(
-            serde_json::to_string(&BreakerKind::Canary).unwrap(),
-            r#""canary""#
-        );
-        let rt: BreakerKind = serde_json::from_str(r#""standard""#).unwrap();
-        assert_eq!(rt, BreakerKind::Standard);
-        let rt: BreakerKind = serde_json::from_str(r#""canary""#).unwrap();
-        assert_eq!(rt, BreakerKind::Canary);
+        for (variant, expected) in [
+            (BreakerKind::ErrorRate, "error_rate"),
+            (BreakerKind::Avg, "avg"),
+            (BreakerKind::P95, "p95"),
+            (BreakerKind::Max, "max"),
+            (BreakerKind::Min, "min"),
+            (BreakerKind::Sum, "sum"),
+            (BreakerKind::Stddev, "stddev"),
+            (BreakerKind::Count, "count"),
+            (BreakerKind::Percentile, "percentile"),
+            (BreakerKind::ConsecutiveFailures, "consecutive_failures"),
+            (BreakerKind::Delta, "delta"),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+            let rt: BreakerKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(rt, variant);
+        }
     }
 
     #[test]
@@ -421,7 +531,6 @@ mod tests {
             (BreakerOp::Gte, "gte"),
             (BreakerOp::Lt, "lt"),
             (BreakerOp::Lte, "lte"),
-            (BreakerOp::Eq, "eq"),
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, format!("\"{expected}\""));
@@ -433,8 +542,9 @@ mod tests {
     #[test]
     fn half_open_policy_serde() {
         for (variant, expected) in [
-            (HalfOpenPolicy::Probabilistic, "probabilistic"),
-            (HalfOpenPolicy::Disabled, "disabled"),
+            (HalfOpenPolicy::Optimistic, "optimistic"),
+            (HalfOpenPolicy::Conservative, "conservative"),
+            (HalfOpenPolicy::Pessimistic, "pessimistic"),
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, format!("\"{expected}\""));
@@ -446,9 +556,9 @@ mod tests {
     #[test]
     fn router_mode_serde() {
         for (variant, expected) in [
-            (RouterMode::Random, "random"),
-            (RouterMode::RoundRobin, "round_robin"),
-            (RouterMode::Hash, "hash"),
+            (RouterMode::Static, "static"),
+            (RouterMode::Canary, "canary"),
+            (RouterMode::Weighted, "weighted"),
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, format!("\"{expected}\""));
@@ -461,9 +571,9 @@ mod tests {
     fn notification_channel_type_serde() {
         for (variant, expected) in [
             (NotificationChannelType::Slack, "slack"),
+            (NotificationChannelType::PagerDuty, "pagerduty"),
             (NotificationChannelType::Email, "email"),
             (NotificationChannelType::Webhook, "webhook"),
-            (NotificationChannelType::PagerDuty, "pager_duty"),
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, format!("\"{expected}\""));
@@ -475,32 +585,12 @@ mod tests {
     #[test]
     fn notification_event_type_serde() {
         for (variant, expected) in [
-            (NotificationEventType::BreakerOpened, "breaker_opened"),
-            (NotificationEventType::BreakerClosed, "breaker_closed"),
-            (
-                NotificationEventType::BreakerHalfOpened,
-                "breaker_half_opened",
-            ),
-            (NotificationEventType::BreakerCreated, "breaker_created"),
-            (NotificationEventType::BreakerDeleted, "breaker_deleted"),
+            (NotificationEventType::Trip, "trip"),
+            (NotificationEventType::Recover, "recover"),
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, format!("\"{expected}\""));
             let rt: NotificationEventType = serde_json::from_str(&json).unwrap();
-            assert_eq!(rt, variant);
-        }
-    }
-
-    #[test]
-    fn breaker_state_value_serde() {
-        for (variant, expected) in [
-            (BreakerStateValue::Open, "open"),
-            (BreakerStateValue::Closed, "closed"),
-            (BreakerStateValue::HalfOpen, "half_open"),
-        ] {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, format!("\"{expected}\""));
-            let rt: BreakerStateValue = serde_json::from_str(&json).unwrap();
             assert_eq!(rt, variant);
         }
     }
@@ -514,26 +604,26 @@ mod tests {
     }
 
     #[test]
-    fn list_params_partial() {
+    fn list_params_with_cursor() {
         let p = ListParams {
-            page: Some(2),
-            per_page: None,
+            cursor: Some("abc123".to_string()),
+            limit: None,
         };
         let pairs = p.to_query_pairs();
         assert_eq!(pairs.len(), 1);
-        assert_eq!(pairs[0], ("page", "2".to_string()));
+        assert_eq!(pairs[0], ("cursor", "abc123".to_string()));
     }
 
     #[test]
     fn list_params_full() {
         let p = ListParams {
-            page: Some(3),
-            per_page: Some(25),
+            cursor: Some("abc".to_string()),
+            limit: Some(25),
         };
         let pairs = p.to_query_pairs();
         assert_eq!(pairs.len(), 2);
-        assert_eq!(pairs[0], ("page", "3".to_string()));
-        assert_eq!(pairs[1], ("per_page", "25".to_string()));
+        assert_eq!(pairs[0], ("cursor", "abc".to_string()));
+        assert_eq!(pairs[1], ("limit", "25".to_string()));
     }
 
     // ── ListEventsParams::to_query_pairs ───────────────────────────
@@ -555,65 +645,64 @@ mod tests {
         assert_eq!(pairs[0], ("breaker_id", "b_123".to_string()));
     }
 
-    #[test]
-    fn list_events_params_full() {
-        let p = ListEventsParams {
-            page: Some(1),
-            per_page: Some(10),
-            breaker_id: Some("b_123".to_string()),
-            event_type: Some("breaker_opened".to_string()),
-        };
-        let pairs = p.to_query_pairs();
-        assert_eq!(pairs.len(), 4);
-    }
-
-    // ── Page<T> deserialization ─────────────────────────────────────
+    // ── Response deserialization ───────────────────────────────────
 
     #[test]
-    fn page_deserialize() {
-        let json = r#"{
-            "data": [{"id":"p1","name":"Proj 1","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}],
-            "page": 1,
-            "per_page": 10,
-            "total": 1,
-            "total_pages": 1
-        }"#;
-        let page: Page<Project> = serde_json::from_str(json).unwrap();
-        assert_eq!(page.data.len(), 1);
-        assert_eq!(page.page, 1);
-        assert_eq!(page.per_page, 10);
-        assert_eq!(page.total, 1);
-        assert_eq!(page.total_pages, 1);
-        assert_eq!(page.data[0].id, "p1");
+    fn list_projects_response_deserialize() {
+        let json =
+            r#"{"projects":[{"project_id":"p1","name":"Proj 1","enable_signed_ingest":false}]}"#;
+        let resp: ListProjectsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.projects.len(), 1);
+        assert_eq!(resp.projects[0].id, "p1");
     }
 
-    // ── Input struct serialization (skip_serializing_if) ───────────
+    #[test]
+    fn list_breakers_response_deserialize() {
+        let json = r#"{"breakers":[{"id":"b1","name":"test","metric":"latency","kind":"error_rate","op":"gt","threshold":0.5}],"count":1}"#;
+        let resp: ListBreakersResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.breakers.len(), 1);
+        assert_eq!(resp.count, 1);
+    }
+
+    #[test]
+    fn list_events_response_deserialize() {
+        let json = r#"{"events":[{"id":"e1","project_id":"p1","breaker_id":"b1","from_state":"closed","to_state":"open"}],"returned":1,"next_cursor":"abc"}"#;
+        let resp: ListEventsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.events.len(), 1);
+        assert_eq!(resp.returned, 1);
+        assert_eq!(resp.next_cursor.as_deref(), Some("abc"));
+    }
+
+    // ── Input struct serialization ─────────────────────────────────
 
     #[test]
     fn create_breaker_input_required_fields_only() {
         let input = CreateBreakerInput {
             name: "api-latency".to_string(),
             metric: "p99_latency".to_string(),
+            kind: BreakerKind::ErrorRate,
+            kind_params: None,
             threshold: 500.0,
             op: BreakerOp::Gt,
-            window_size: 300,
-            min_samples: 100,
-            kind: None,
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
+            window_ms: None,
+            min_count: None,
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
             metadata: None,
         };
         let json = serde_json::to_string(&input).unwrap();
         assert!(json.contains("\"name\":\"api-latency\""));
+        assert!(json.contains("\"kind\":\"error_rate\""));
         assert!(json.contains("\"threshold\":500.0"));
         assert!(json.contains("\"op\":\"gt\""));
-        // None fields should be omitted
-        assert!(!json.contains("\"kind\""));
-        assert!(!json.contains("\"description\""));
+        assert!(!json.contains("\"window_ms\""));
         assert!(!json.contains("\"metadata\""));
-        assert!(!json.contains("\"half_open_policy\""));
     }
 
     #[test]
@@ -621,36 +710,49 @@ mod tests {
         let input = CreateBreakerInput {
             name: "test".to_string(),
             metric: "latency".to_string(),
+            kind: BreakerKind::Avg,
+            kind_params: None,
             threshold: 100.0,
             op: BreakerOp::Gte,
-            window_size: 60,
-            min_samples: 10,
-            kind: Some(BreakerKind::Standard),
-            description: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
-            metadata: Some(serde_json::json!({"region": "us-east-1", "team": "payments"})),
+            window_ms: Some(60000),
+            min_count: Some(10),
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
+            metadata: Some(HashMap::from([(
+                "region".to_string(),
+                "us-east-1".to_string(),
+            )])),
         };
         let json = serde_json::to_string(&input).unwrap();
         assert!(json.contains("\"metadata\""));
         assert!(json.contains("us-east-1"));
-        assert!(json.contains("payments"));
     }
 
     #[test]
     fn update_breaker_input_single_field() {
         let input = UpdateBreakerInput {
             name: Some("new-name".to_string()),
-            description: None,
             metric: None,
+            kind: None,
+            kind_params: None,
             threshold: None,
             op: None,
-            window_size: None,
-            min_samples: None,
-            half_open_policy: None,
-            half_open_max_rate: None,
-            cooldown: None,
+            window_ms: None,
+            min_count: None,
+            min_state_duration_ms: None,
+            cooldown_ms: None,
+            eval_interval_ms: None,
+            half_open_backoff_enabled: None,
+            half_open_backoff_cap_ms: None,
+            half_open_indeterminate_policy: None,
+            recovery_allow_rate_ramp_steps: None,
+            actions: None,
             metadata: None,
         };
         let json = serde_json::to_string(&input).unwrap();
@@ -658,55 +760,44 @@ mod tests {
     }
 
     #[test]
-    fn create_project_input_without_description() {
+    fn create_project_input_serialization() {
         let input = CreateProjectInput {
             name: "my-project".to_string(),
-            description: None,
         };
         let json = serde_json::to_string(&input).unwrap();
         assert_eq!(json, r#"{"name":"my-project"}"#);
     }
 
     #[test]
-    fn create_project_input_with_description() {
-        let input = CreateProjectInput {
-            name: "my-project".to_string(),
-            description: Some("A test project".to_string()),
-        };
-        let json = serde_json::to_string(&input).unwrap();
-        assert!(json.contains("\"description\":\"A test project\""));
-    }
-
-    #[test]
     fn create_router_input_with_mode() {
         let input = CreateRouterInput {
             name: "my-router".to_string(),
+            mode: RouterMode::Static,
             description: None,
-            mode: Some(RouterMode::RoundRobin),
+            enabled: None,
             metadata: None,
         };
         let json = serde_json::to_string(&input).unwrap();
-        assert!(json.contains("\"mode\":\"round_robin\""));
+        assert!(json.contains("\"mode\":\"static\""));
         assert!(!json.contains("\"description\""));
     }
 
     #[test]
-    fn create_notification_channel_input_with_channel_type() {
+    fn create_notification_channel_input_with_channel() {
         let input = CreateNotificationChannelInput {
             name: "my-channel".to_string(),
-            channel_type: NotificationChannelType::Slack,
+            channel: NotificationChannelType::Slack,
             config: None,
             events: Some(vec![
-                NotificationEventType::BreakerOpened,
-                NotificationEventType::BreakerClosed,
+                NotificationEventType::Trip,
+                NotificationEventType::Recover,
             ]),
-            breaker_ids: None,
             enabled: None,
         };
         let json = serde_json::to_string(&input).unwrap();
-        assert!(json.contains("\"channel_type\":\"slack\""));
-        assert!(json.contains("\"breaker_opened\""));
-        assert!(json.contains("\"breaker_closed\""));
+        assert!(json.contains("\"channel\":\"slack\""));
+        assert!(json.contains("\"trip\""));
+        assert!(json.contains("\"recover\""));
     }
 
     #[test]
@@ -722,9 +813,20 @@ mod tests {
     fn update_project_input_single_field() {
         let input = UpdateProjectInput {
             name: Some("Updated Name".to_string()),
-            description: None,
+            slack_webhook_url: None,
+            trace_id_url_template: None,
+            enable_signed_ingest: None,
         };
         let json = serde_json::to_string(&input).unwrap();
         assert_eq!(json, r#"{"name":"Updated Name"}"#);
+    }
+
+    #[test]
+    fn project_deserialize_with_rename() {
+        let json = r#"{"project_id":"p1","name":"Test","enable_signed_ingest":true}"#;
+        let project: Project = serde_json::from_str(json).unwrap();
+        assert_eq!(project.id, "p1");
+        assert_eq!(project.name, "Test");
+        assert!(project.enable_signed_ingest);
     }
 }

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -68,7 +68,8 @@ pub enum NotificationEventType {
 pub struct Project {
     #[serde(rename = "project_id")]
     pub id: String,
-    pub name: String,
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slack_webhook_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -185,9 +186,9 @@ pub struct ProjectKey {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_used_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub inserted_at: Option<DateTime<Utc>>,
+    pub inserted_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -210,6 +211,8 @@ pub struct IngestSecretRotation {
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateProjectInput {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -379,7 +382,8 @@ pub struct Workspace {
     pub name: String,
     pub slug: String,
     pub org_id: String,
-    pub inserted_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inserted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -433,7 +437,7 @@ pub struct ListEventsResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListNotificationChannelsResponse {
-    pub items: Vec<NotificationChannel>,
+    pub channels: Vec<NotificationChannel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
@@ -763,6 +767,7 @@ mod tests {
     fn create_project_input_serialization() {
         let input = CreateProjectInput {
             name: "my-project".to_string(),
+            workspace_id: None,
         };
         let json = serde_json::to_string(&input).unwrap();
         assert_eq!(json, r#"{"name":"my-project"}"#);
@@ -826,7 +831,7 @@ mod tests {
         let json = r#"{"project_id":"p1","name":"Test","enable_signed_ingest":true}"#;
         let project: Project = serde_json::from_str(json).unwrap();
         assert_eq!(project.id, "p1");
-        assert_eq!(project.name, "Test");
+        assert_eq!(project.name.as_deref(), Some("Test"));
         assert!(project.enable_signed_ingest);
     }
 }

--- a/src/admin/workspaces.rs
+++ b/src/admin/workspaces.rs
@@ -1,0 +1,95 @@
+use super::errors::AdminError;
+use super::types::*;
+use super::{AdminClient, RequestOptions};
+
+impl AdminClient {
+    pub async fn list_workspaces(&self) -> Result<ListWorkspacesResponse, AdminError> {
+        self.list_workspaces_with_opts(None).await
+    }
+
+    pub async fn list_workspaces_with_opts(
+        &self,
+        opts: Option<&RequestOptions>,
+    ) -> Result<ListWorkspacesResponse, AdminError> {
+        let builder = self
+            .http
+            .get(self.url("/v1/workspaces"))
+            .headers(self.auth_headers());
+        self.do_request(builder, opts).await
+    }
+
+    pub async fn create_workspace(
+        &self,
+        input: &CreateWorkspaceInput,
+    ) -> Result<Workspace, AdminError> {
+        self.create_workspace_with_opts(input, None).await
+    }
+
+    pub async fn create_workspace_with_opts(
+        &self,
+        input: &CreateWorkspaceInput,
+        opts: Option<&RequestOptions>,
+    ) -> Result<Workspace, AdminError> {
+        let builder = self
+            .http
+            .post(self.url("/v1/workspaces"))
+            .headers(self.auth_headers())
+            .json(input);
+        self.do_request(builder, opts).await
+    }
+
+    pub async fn get_workspace(&self, workspace_id: &str) -> Result<Workspace, AdminError> {
+        self.get_workspace_with_opts(workspace_id, None).await
+    }
+
+    pub async fn get_workspace_with_opts(
+        &self,
+        workspace_id: &str,
+        opts: Option<&RequestOptions>,
+    ) -> Result<Workspace, AdminError> {
+        let builder = self
+            .http
+            .get(self.url(&format!("/v1/workspaces/{workspace_id}")))
+            .headers(self.auth_headers());
+        self.do_request(builder, opts).await
+    }
+
+    pub async fn update_workspace(
+        &self,
+        workspace_id: &str,
+        input: &UpdateWorkspaceInput,
+    ) -> Result<Workspace, AdminError> {
+        self.update_workspace_with_opts(workspace_id, input, None)
+            .await
+    }
+
+    pub async fn update_workspace_with_opts(
+        &self,
+        workspace_id: &str,
+        input: &UpdateWorkspaceInput,
+        opts: Option<&RequestOptions>,
+    ) -> Result<Workspace, AdminError> {
+        let builder = self
+            .http
+            .patch(self.url(&format!("/v1/workspaces/{workspace_id}")))
+            .headers(self.auth_headers())
+            .json(input);
+        self.do_request(builder, opts).await
+    }
+
+    pub async fn delete_workspace(&self, workspace_id: &str) -> Result<(), AdminError> {
+        self.delete_workspace_with_opts(workspace_id, None).await
+    }
+
+    pub async fn delete_workspace_with_opts(
+        &self,
+        workspace_id: &str,
+        opts: Option<&RequestOptions>,
+    ) -> Result<(), AdminError> {
+        let builder = self
+            .http
+            .delete(self.url(&format!("/v1/workspaces/{workspace_id}")))
+            .headers(self.auth_headers());
+        self.do_request_no_content(builder, opts).await
+    }
+}

--- a/tests/admin_integration.rs
+++ b/tests/admin_integration.rs
@@ -28,7 +28,7 @@ async fn test_list_breakers() {
     let client = admin_client();
     let pid = project_id();
     let resp = client.list_breakers(&pid, None).await.unwrap();
-    assert!(resp.total >= 0);
+    assert!(resp.count >= 0);
 }
 
 #[tokio::test]
@@ -37,7 +37,8 @@ async fn test_list_routers() {
     let client = admin_client();
     let pid = project_id();
     let resp = client.list_routers(&pid, None).await.unwrap();
-    assert!(resp.total >= 0);
+    // routers response doesn't have a count field, just check it doesn't error
+    let _ = resp.routers;
 }
 
 #[tokio::test]
@@ -46,7 +47,7 @@ async fn test_list_events() {
     let client = admin_client();
     let pid = project_id();
     let resp = client.list_events(&pid, None).await.unwrap();
-    assert!(resp.total >= 0);
+    assert!(resp.returned >= 0);
 }
 
 #[tokio::test]
@@ -55,7 +56,8 @@ async fn test_list_notification_channels() {
     let client = admin_client();
     let pid = project_id();
     let resp = client.list_notification_channels(&pid, None).await.unwrap();
-    assert!(resp.total >= 0);
+    // items list is present
+    let _ = resp.items;
 }
 
 #[tokio::test]
@@ -68,15 +70,20 @@ async fn test_breaker_crud() {
     let input = CreateBreakerInput {
         name: format!("test-breaker-rs-{}", chrono::Utc::now().timestamp()),
         metric: "error_rate".to_string(),
+        kind: BreakerKind::ErrorRate,
+        kind_params: None,
         threshold: 0.5,
         op: BreakerOp::Gt,
-        window_size: 60000,
-        min_samples: 10,
-        kind: None,
-        description: Some("test breaker from Rust SDK".to_string()),
-        half_open_policy: None,
-        half_open_max_rate: None,
-        cooldown: None,
+        window_ms: Some(60000),
+        min_count: Some(10),
+        min_state_duration_ms: None,
+        cooldown_ms: None,
+        eval_interval_ms: None,
+        half_open_backoff_enabled: None,
+        half_open_backoff_cap_ms: None,
+        half_open_indeterminate_policy: None,
+        recovery_allow_rate_ramp_steps: None,
+        actions: None,
         metadata: None,
     };
     let breaker = client.create_breaker(&pid, &input).await.unwrap();
@@ -88,23 +95,29 @@ async fn test_breaker_crud() {
 
     // Update
     let update = UpdateBreakerInput {
-        description: Some("updated description".to_string()),
+        threshold: Some(0.8),
         name: None,
         metric: None,
-        threshold: None,
+        kind: None,
+        kind_params: None,
         op: None,
-        window_size: None,
-        min_samples: None,
-        half_open_policy: None,
-        half_open_max_rate: None,
-        cooldown: None,
+        window_ms: None,
+        min_count: None,
+        min_state_duration_ms: None,
+        cooldown_ms: None,
+        eval_interval_ms: None,
+        half_open_backoff_enabled: None,
+        half_open_backoff_cap_ms: None,
+        half_open_indeterminate_policy: None,
+        recovery_allow_rate_ramp_steps: None,
+        actions: None,
         metadata: None,
     };
     let updated = client
         .update_breaker(&pid, &breaker.id, &update)
         .await
         .unwrap();
-    assert_eq!(updated.description.as_deref(), Some("updated description"));
+    assert!((updated.threshold - 0.8).abs() < f64::EPSILON);
 
     // Delete
     client.delete_breaker(&pid, &breaker.id).await.unwrap();

--- a/tests/admin_integration.rs
+++ b/tests/admin_integration.rs
@@ -114,13 +114,27 @@ async fn test_breaker_crud() {
 
     let update = UpdateBreakerInput {
         threshold: Some(0.8),
-        name: None, metric: None, kind: None, kind_params: None, op: None,
-        window_ms: None, min_count: None, min_state_duration_ms: None,
-        cooldown_ms: None, eval_interval_ms: None, half_open_backoff_enabled: None,
-        half_open_backoff_cap_ms: None, half_open_indeterminate_policy: None,
-        recovery_allow_rate_ramp_steps: None, actions: None, metadata: None,
+        name: None,
+        metric: None,
+        kind: None,
+        kind_params: None,
+        op: None,
+        window_ms: None,
+        min_count: None,
+        min_state_duration_ms: None,
+        cooldown_ms: None,
+        eval_interval_ms: None,
+        half_open_backoff_enabled: None,
+        half_open_backoff_cap_ms: None,
+        half_open_indeterminate_policy: None,
+        recovery_allow_rate_ramp_steps: None,
+        actions: None,
+        metadata: None,
     };
-    let updated = client.update_breaker(&pid, &breaker.id, &update).await.unwrap();
+    let updated = client
+        .update_breaker(&pid, &breaker.id, &update)
+        .await
+        .unwrap();
     assert!((updated.threshold - 0.8).abs() < f64::EPSILON);
 
     client.delete_breaker(&pid, &breaker.id).await.unwrap();

--- a/tests/admin_integration.rs
+++ b/tests/admin_integration.rs
@@ -1,4 +1,4 @@
-use tripswitch::admin::{types::*, AdminClient};
+use tripswitch::admin::{errors::AdminError, types::*, AdminClient};
 
 fn admin_client() -> AdminClient {
     let api_key = std::env::var("TRIPSWITCH_API_KEY").expect("TRIPSWITCH_API_KEY must be set");
@@ -9,9 +9,23 @@ fn admin_client() -> AdminClient {
     builder.build()
 }
 
+fn bad_client() -> AdminClient {
+    let mut builder = AdminClient::builder("eb_admin_invalid".to_string());
+    if let Ok(url) = std::env::var("TRIPSWITCH_BASE_URL") {
+        builder = builder.base_url(url);
+    }
+    builder.build()
+}
+
 fn project_id() -> String {
     std::env::var("TRIPSWITCH_PROJECT_ID").expect("TRIPSWITCH_PROJECT_ID must be set")
 }
+
+fn workspace_id() -> Option<String> {
+    std::env::var("TRIPSWITCH_WORKSPACE_ID").ok()
+}
+
+// ── Projects ─────────────────────────────────────────────────────────
 
 #[tokio::test]
 #[ignore]
@@ -24,6 +38,42 @@ async fn test_get_project() {
 
 #[tokio::test]
 #[ignore]
+async fn test_list_projects() {
+    let client = admin_client();
+    let pid = project_id();
+    let resp = client.list_projects().await.unwrap();
+    assert!(resp.projects.iter().any(|p| p.id == pid));
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_project_crud() {
+    let client = admin_client();
+    let name = format!("integration-test-rs-{}", chrono::Utc::now().timestamp());
+
+    let input = CreateProjectInput {
+        name: name.clone(),
+        workspace_id: workspace_id(),
+    };
+    let project = client.create_project(&input).await.unwrap();
+    assert_eq!(project.name.as_deref(), Some(name.as_str()));
+
+    // List — should appear
+    let resp = client.list_projects().await.unwrap();
+    assert!(resp.projects.iter().any(|p| p.id == project.id));
+
+    // Delete
+    client.delete_project(&project.id, &name).await.unwrap();
+
+    // Verify gone
+    let result = client.get_project(&project.id).await;
+    assert!(result.is_err());
+}
+
+// ── Breakers ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
 async fn test_list_breakers() {
     let client = admin_client();
     let pid = project_id();
@@ -33,40 +83,10 @@ async fn test_list_breakers() {
 
 #[tokio::test]
 #[ignore]
-async fn test_list_routers() {
-    let client = admin_client();
-    let pid = project_id();
-    let resp = client.list_routers(&pid, None).await.unwrap();
-    // routers response doesn't have a count field, just check it doesn't error
-    let _ = resp.routers;
-}
-
-#[tokio::test]
-#[ignore]
-async fn test_list_events() {
-    let client = admin_client();
-    let pid = project_id();
-    let resp = client.list_events(&pid, None).await.unwrap();
-    assert!(resp.returned >= 0);
-}
-
-#[tokio::test]
-#[ignore]
-async fn test_list_notification_channels() {
-    let client = admin_client();
-    let pid = project_id();
-    let resp = client.list_notification_channels(&pid, None).await.unwrap();
-    // items list is present
-    let _ = resp.items;
-}
-
-#[tokio::test]
-#[ignore]
 async fn test_breaker_crud() {
     let client = admin_client();
     let pid = project_id();
 
-    // Create
     let input = CreateBreakerInput {
         name: format!("test-breaker-rs-{}", chrono::Utc::now().timestamp()),
         metric: "error_rate".to_string(),
@@ -89,40 +109,104 @@ async fn test_breaker_crud() {
     let breaker = client.create_breaker(&pid, &input).await.unwrap();
     assert_eq!(breaker.metric, "error_rate");
 
-    // Get
     let fetched = client.get_breaker(&pid, &breaker.id).await.unwrap();
     assert_eq!(fetched.id, breaker.id);
 
-    // Update
     let update = UpdateBreakerInput {
         threshold: Some(0.8),
-        name: None,
-        metric: None,
-        kind: None,
-        kind_params: None,
-        op: None,
-        window_ms: None,
-        min_count: None,
-        min_state_duration_ms: None,
-        cooldown_ms: None,
-        eval_interval_ms: None,
-        half_open_backoff_enabled: None,
-        half_open_backoff_cap_ms: None,
-        half_open_indeterminate_policy: None,
-        recovery_allow_rate_ramp_steps: None,
-        actions: None,
-        metadata: None,
+        name: None, metric: None, kind: None, kind_params: None, op: None,
+        window_ms: None, min_count: None, min_state_duration_ms: None,
+        cooldown_ms: None, eval_interval_ms: None, half_open_backoff_enabled: None,
+        half_open_backoff_cap_ms: None, half_open_indeterminate_policy: None,
+        recovery_allow_rate_ramp_steps: None, actions: None, metadata: None,
     };
-    let updated = client
-        .update_breaker(&pid, &breaker.id, &update)
-        .await
-        .unwrap();
+    let updated = client.update_breaker(&pid, &breaker.id, &update).await.unwrap();
     assert!((updated.threshold - 0.8).abs() < f64::EPSILON);
 
-    // Delete
     client.delete_breaker(&pid, &breaker.id).await.unwrap();
 
-    // Verify deleted
     let result = client.get_breaker(&pid, &breaker.id).await;
     assert!(result.is_err());
+}
+
+// ── Routers ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_list_routers() {
+    let client = admin_client();
+    let pid = project_id();
+    let resp = client.list_routers(&pid, None).await.unwrap();
+    let _ = resp.routers;
+}
+
+// ── Notification Channels ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_list_notification_channels() {
+    let client = admin_client();
+    let pid = project_id();
+    let resp = client.list_notification_channels(&pid, None).await.unwrap();
+    let _ = resp.channels;
+}
+
+// ── Events ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_list_events() {
+    let client = admin_client();
+    let pid = project_id();
+    let resp = client.list_events(&pid, None).await.unwrap();
+    assert!(resp.returned >= 0);
+}
+
+// ── Project Keys ──────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_list_project_keys() {
+    let client = admin_client();
+    let pid = project_id();
+    let resp = client.list_project_keys(&pid).await.unwrap();
+    let _ = resp.keys;
+}
+
+// ── Workspaces ────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_get_workspace() {
+    let wid = match workspace_id() {
+        Some(id) => id,
+        None => return, // skip if not configured
+    };
+    let client = admin_client();
+    let ws = client.get_workspace(&wid).await.unwrap();
+    assert_eq!(ws.id, wid);
+}
+
+// ── Error Handling ────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_not_found_error() {
+    let client = admin_client();
+    let err = client
+        .get_project("00000000-0000-0000-0000-000000000000")
+        .await
+        .unwrap_err();
+    assert!(err.is_not_found(), "expected not_found, got: {err:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_unauthorized_error() {
+    let client = bad_client();
+    let err = client.get_project("any").await.unwrap_err();
+    assert!(
+        matches!(err, AdminError::Unauthorized(_)),
+        "expected unauthorized, got: {err:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Propagates two changes from the Go SDK (v0.12.0) and brings the integration test suite into parity across all SDKs:

- **Workspace CRUD**: adds `Workspace`, `CreateWorkspaceInput`, `UpdateWorkspaceInput`, `ListWorkspacesResponse` types and a new `src/admin/workspaces.rs` module with `list_workspaces`, `create_workspace`, `get_workspace`, `update_workspace`, `delete_workspace` methods (each with `_with_opts` variant).
- **Breaker `router_id` → `router_ids`**: `Breaker.router_id: Option<String>` renamed to `router_ids: Vec<String>` with `serde(default)`.
- **Breaker envelope unwrapping**: single-breaker endpoints (`GET`/`POST`/`PATCH`) return `{"breaker": {...}, "router_ids": [...]}` — added `BreakerEnvelope` struct and `unwrap_breaker_env` helper; used in `get_breaker`, `create_breaker`, `update_breaker`, `update_breaker_metadata`.
- **`ListNotificationChannelsResponse`**: renamed field `items` → `channels` to match API response shape.
- **`CreateProjectInput`**: added optional `workspace_id` field (`skip_serializing_if = "Option::is_none"`).
- **Type fixes from live API**: `Project.name` → `Option<String>` (API can return `null`); `Workspace.inserted_at` → `Option<DateTime<Utc>>` (omitted by API); `ProjectKey` timestamp fields changed to `Option<String>` (API returns timestamps without timezone).
- **Integration test expansion** (12 tests total): added `test_list_projects`, `test_project_crud`, `test_list_project_keys`, `test_get_workspace`, `test_not_found_error`, `test_unauthorized_error`; added `bad_client()` and `workspace_id()` helpers.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 151 unit tests, 0 failures
- [x] `cargo fmt` — no changes
- [x] `cargo clippy` — no errors
- [x] Integration tests — 12 passed against local dev server