### PR TITLE
docs: fix README install snippet version (0.1 -> 0.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tripswitch = "0.1"
+tripswitch = "0.1.1"
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 


### PR DESCRIPTION
## What changed

The installation snippet in `README.md` referenced `tripswitch = "0.1"`, but the current published version in `Cargo.toml` is `0.1.1`.

## Why

Users copying the dependency line from the README would pin to an older version. This one-line fix aligns the docs with the actual crate version.